### PR TITLE
ci: Use script to determine apps to build, don't build if no apps changed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,21 +39,53 @@ jobs:
           dir_names_max_depth: "1"
           path: apps
 
+      - name: Setup Node
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+
+      - name: Install required packages
+        run: npm install yaml
+
       - name: Extract Metadata
         id: apps
-        working-directory: apps
-        run: |
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
-              apps="${{ steps.changed-dirs.outputs.all_changed_and_modified_files }}"
-          else
-              apps="${{ inputs.app }}"
-          fi
-          apps=$(printf "%s/metadata.yaml\n" ${apps})
-          apps=$(yq eval-all --indent=0 --output-format=json "[.]" ${apps})
-          echo "apps=${apps}" >> $GITHUB_OUTPUT
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('yaml');
+            const cwd = process.cwd();
+
+            let input = '';
+            if (context.eventName == 'workflow_dispatch') {
+              input = '${{ inputs.app }}';
+            } else {
+              input = '${{ steps.changed-dirs.outputs.all_changed_and_modified_files }}';
+            }
+
+            appsToBuild = input.split(' ').filter((v) => v !== '');
+
+            let output = [];
+            appsToBuild.forEach(function(app) {
+              const metadataPath = `${cwd}/apps/${app}/metadata.yaml`;
+              if (!fs.existsSync(metadataPath)) {
+                core.setFailed(`App ${app} does not have a metadata.yaml`);
+                process.exit(1);
+              }
+
+              metadataContent = fs.readFileSync(metadataPath, {encoding: "utf8"});
+              metadata = yaml.parse(metadataContent);
+
+              output.push(metadata);
+            });
+
+            core.setOutput('apps', output);
+
+            console.log('apps:');
+            console.log(JSON.stringify(output, null, 2));
+            core.summary.addHeading('Apps to build:').addList(appsToBuild).write()
 
   build:
     needs: changed
+    if: ${{ needs.changed.outputs.apps != '[]' }}
     name: Build ${{ matrix.app.name }}
     uses: ./.github/workflows/image-build-action.yaml
     permissions:
@@ -70,7 +102,7 @@ jobs:
       release: ${{ github.event_name == 'workflow_dispatch' && inputs.release || github.event_name == 'push' }}
 
   status:
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     needs: build
     name: Build Success
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,8 +84,8 @@ jobs:
             core.summary.addHeading('Apps to build:').addList(appsToBuild).write()
 
   build:
-    needs: changed
     if: ${{ needs.changed.outputs.apps != '[]' }}
+    needs: changed
     name: Build ${{ matrix.app.name }}
     uses: ./.github/workflows/image-build-action.yaml
     permissions:


### PR DESCRIPTION
This PR makes it so we don't rely on `bash` and `yq` magic to build the list of images to build, but instead can use proper typescript. It also prints the list of changed images to the step stummary.

Additionally the change adds a quick `if` check to the build step. It seems obsolete for now because the entire workflow only runs when files in `apps/**` change, but if this were to ever change this is a nice and simple way to prevent accidental builds.