### PR TITLE
fix(actions-runner): add brew back for amd64

### DIFF
--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -17,15 +17,21 @@ RUN \
     apt-get -qq install -y --no-install-recommends --no-install-suggests \
         ca-certificates \
         curl \
-        gcc \
         jo \
         moreutils \
         wget \
         zstd \
+    && \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+        apt-get -qq install -y --no-install-recommends --no-install-suggests gcc \
+    if \
     && curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq \
     && rm -rf /var/lib/apt/lists/*
 
 USER runner
 
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+RUN \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"; \
+    fi

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -2,7 +2,10 @@ ARG VERSION
 FROM ghcr.io/actions/actions-runner:${VERSION}
 ARG TARGETARCH
 
-ENV DEBCONF_NONINTERACTIVE_SEEN=true \
+ENV HOMEBREW_NO_ANALYTICS=1 \
+    HOMEBREW_NO_ENV_HINTS=1 \
+    HOMEBREW_NO_INSTALL_CLEANUP=1 \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
     DEBIAN_FRONTEND="noninteractive" \
     APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 
@@ -24,3 +27,5 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 USER runner
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -22,8 +22,8 @@ RUN \
         wget \
         zstd \
     && \
-    case "${TARGETPLATFORM}" in \
-        'linux/amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests gcc ;; \
+    case "${TARGETARCH}" in \
+        'amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests gcc ;; \
     esac \
     && curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq \
@@ -32,6 +32,6 @@ RUN \
 USER runner
 
 RUN \
-    case "${TARGETPLATFORM}" in \
-        'linux/amd64') /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" ;; \
+    case "${TARGETARCH}" in \
+        'amd64') /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" ;; \
     esac

--- a/apps/actions-runner/Dockerfile
+++ b/apps/actions-runner/Dockerfile
@@ -22,9 +22,9 @@ RUN \
         wget \
         zstd \
     && \
-    if [ "${TARGETARCH}" = "amd64" ]; then \
-        apt-get -qq install -y --no-install-recommends --no-install-suggests gcc \
-    if \
+    case "${TARGETPLATFORM}" in \
+        'linux/amd64') apt-get -qq install -y --no-install-recommends --no-install-suggests gcc ;; \
+    esac \
     && curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq \
     && rm -rf /var/lib/apt/lists/*
@@ -32,6 +32,6 @@ RUN \
 USER runner
 
 RUN \
-    if [ "${TARGETARCH}" = "amd64" ]; then \
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"; \
-    fi
+    case "${TARGETPLATFORM}" in \
+        'linux/amd64') /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" ;; \
+    esac


### PR DESCRIPTION
@buroa was there a reason this was removed? It could still come in handy in places. There's no way to get brew installed without these changes.