### PR TITLE
ci: pin base images for certain containers

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -50,7 +50,7 @@
       description: ["Allowed versions for Ubuntu"],
       matchDatasources: ["docker"],
       matchPackageNames: ["/ubuntu/"],
-      allowedVersions: "/24.04/",
+      allowedVersions: "/24\\.04/",
     },
     {
       description: ["Allowed versions for Bazarr and JBOPS"],
@@ -60,14 +60,14 @@
         "apps/jbops/Dockerfile",
       ],
       matchPackageNames: ["/python/"],
-      allowedVersions: "/3.12-alpine/",
+      allowedVersions: "/3\\.12-alpine/",
     },
     {
       description: ["Allowed versions for Beets"],
       matchDatasources: ["docker"],
       matchFileNames: ["apps/beets/Dockerfile"],
       matchPackageNames: ["/node/"],
-      allowedVersions: "/16-alpine3.18/",
+      allowedVersions: "/16-alpine3\\.18/",
     },
   ],
 }

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -46,5 +46,28 @@
       automergeType: "pr",
       ignoreTests: false,
     },
+    {
+      description: ["Allowed versions for Ubuntu"],
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/ubuntu/"],
+      allowedVersions: "/24.04/",
+    },
+    {
+      description: ["Allowed versions for Bazarr and JBOPS"],
+      matchDatasources: ["docker"],
+      matchFileNames: [
+        "apps/bazarr/Dockerfile",
+        "apps/jbops/Dockerfile",
+      ],
+      matchPackageNames: ["/python/"],
+      allowedVersions: "/3.12-alpine/",
+    },
+    {
+      description: ["Allowed versions for Beets"],
+      matchDatasources: ["docker"],
+      matchFileNames: ["apps/beets/Dockerfile"],
+      matchPackageNames: ["/node/"],
+      allowedVersions: "/16-alpine3.18/",
+    },
   ],
 }

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -47,13 +47,13 @@
       ignoreTests: false,
     },
     {
-      description: ["Allowed versions for Ubuntu"],
+      description: ["Allowed Ubuntu versions for all container images"],
       matchDatasources: ["docker"],
       matchPackageNames: ["/ubuntu/"],
       allowedVersions: "/24\\.04/",
     },
     {
-      description: ["Allowed versions for Bazarr and JBOPS"],
+      description: ["Allowed Python versions for Bazarr and JBOPS"],
       matchDatasources: ["docker"],
       matchFileNames: [
         "apps/bazarr/Dockerfile",
@@ -63,7 +63,7 @@
       allowedVersions: "/3\\.12-alpine/",
     },
     {
-      description: ["Allowed versions for Beets"],
+      description: ["Allowed Node versions for Beets"],
       matchDatasources: ["docker"],
       matchFileNames: ["apps/beets/Dockerfile"],
       matchPackageNames: ["/node/"],

--- a/apps/plex/Dockerfile
+++ b/apps/plex/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:25.04
+FROM docker.io/library/ubuntu:24.04
 
 ARG TARGETARCH
 ARG VENDOR


### PR DESCRIPTION
This also switches Plex back to 24.04 which is the LTS, I can't see a reason to use releases after that?