### PR TITLE
ci: improve attestation

### DIFF
--- a/.github/workflows/image-build-action.yaml
+++ b/.github/workflows/image-build-action.yaml
@@ -202,12 +202,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
-
-      - name: Sign Digest
-        run: cosign sign --yes ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
-
       - name: Generate and Upload SBOM
         uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
         with:

--- a/.github/workflows/image-build-action.yaml
+++ b/.github/workflows/image-build-action.yaml
@@ -208,7 +208,7 @@ jobs:
           dependency-snapshot: true
           image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
 
-      - name: Attest
+      - name: Attestation
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           push-to-registry: true

--- a/.github/workflows/image-build-action.yaml
+++ b/.github/workflows/image-build-action.yaml
@@ -161,6 +161,8 @@ jobs:
       - name: Build Meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         id: meta
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           flavor: latest=false
           images: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}
@@ -206,33 +208,23 @@ jobs:
       - name: Sign Digest
         run: cosign sign --yes ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
 
-      - name: Generate SBOM
+      - name: Generate and Upload SBOM
         uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
         with:
-          format: spdx-json
+          dependency-snapshot: true
           image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
-          output-file: ${{ inputs.app }}-sbom.spdx.json
-
-      - name: Scan SBOM
-        uses: anchore/scan-action@7c05671ae9be166aeb155bad2d7df9121823df32 # v6.1.0
-        id: scan
-        with:
-          fail-build: false
-          sbom: ${{ inputs.app }}-sbom.spdx.json
 
       - name: Attest
-        uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
-        id: attest
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         with:
           push-to-registry: true
-          sbom-path: ${{ inputs.app }}-sbom.spdx.json
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}
           subject-digest: ${{ needs.release.outputs.digest }}
 
-      - name: Upload SARIF Report
-        uses: github/codeql-action/upload-sarif@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
+      - name: Verify Attestation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: gh attestation verify --repo ${{ github.repository }} oci://ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
 
   notify:
     if: ${{ inputs.release && !cancelled() }}

--- a/.github/workflows/image-build-action.yaml
+++ b/.github/workflows/image-build-action.yaml
@@ -202,7 +202,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Generate and Upload SBOM
+      - name: Upload Dependency Snapshot
         uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
         with:
           dependency-snapshot: true


### PR DESCRIPTION
- Removed code scanning, opened #236 to be completed in another PR.
- Added [annotations to the file index](https://docs.docker.com/build/metadata/annotations/) because [GitHub package overview](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images) will show more information
- Switched to [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance?tab=readme-ov-file), this should also remove the need for cosign (see [here](https://github.com/actions/attest-build-provenance/issues/62#issuecomment-2096500208))
- Added Verify Attestation step