### PR TITLE
fix(theme-park): Fix Directory Structure

### DIFF
--- a/apps/theme-park/Dockerfile
+++ b/apps/theme-park/Dockerfile
@@ -4,20 +4,20 @@ ARG VERSION
 #hadolint ignore=DL3008
 RUN \
     apk add --no-cache \
-        curl \
-        grep \
-        sed \
-        tar \
+    curl \
+    grep \
+    sed \
+    tar \
     && \
     curl -fsSL "https://github.com/themepark-dev/theme.park/archive/${VERSION}.tar.gz" \
-        | tar xzf - -C /tmp --strip-components 1 \
+    | tar xzf - -C /tmp --strip-components 1 \
     && python /tmp/themes.py \
     && grep -rl 'https://theme-park.dev' /tmp | xargs sed -i 's|https\://theme-park.dev||g'
 
 FROM ghcr.io/nginxinc/nginx-unprivileged:1.27-alpine
-COPY --from=builder --chown=nginx:nginx /tmp/index.html /usr/share/nginx/html
-COPY --from=builder --chown=nginx:nginx /tmp/css /usr/share/nginx/html
-COPY --from=builder --chown=nginx:nginx /tmp/resources /usr/share/nginx/html
+COPY --from=builder --chown=nginx:nginx /tmp/index.html /usr/share/nginx/html/
+COPY --from=builder --chown=nginx:nginx /tmp/css /usr/share/nginx/html/css/
+COPY --from=builder --chown=nginx:nginx /tmp/resources /usr/share/nginx/html/resources/
 USER nginx
 WORKDIR /usr/share/nginx/html
 LABEL org.opencontainers.image.source="https://github.com/themepark-dev/theme.park"


### PR DESCRIPTION
The old version dumped everything right into `/usr/share/nginx/html/` instead of sorting stuff into folders like `css/` and `resources/`. This tweak fixes the Dockerfile so files end up where they’re supposed to be, making sure everything works as expected.

Tested on my containers repo and this fixed the directory path issues I was having. 

Also neovim auto formatted on write.. so just a couple indentation changes. 