### PR TITLE
ci: add container size diff job

### DIFF
--- a/.github/actions/container-size-diff/action.yml
+++ b/.github/actions/container-size-diff/action.yml
@@ -1,0 +1,37 @@
+---
+name: Container Size Diff
+description: Creates a Markdown summary of the size difference between two container versions
+
+inputs:
+  from-container:
+    description: Baseline container image for size comparison
+    required: true
+  to-container:
+    description: Container image to be compared to the baseline
+    required: true
+
+outputs:
+  size-diff-markdown:
+    description: Markdown formatted output of container size comparison
+    value: ${{ steps.size-diff.outputs.markdown }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set GitHub Action Path
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+      run: echo "$GITHUB_ACTION_PATH" >> "$GITHUB_PATH"
+
+    - name: Container Size Diff
+      id: size-diff
+      shell: bash
+      env:
+        INPUT_FROM_CONTAINER: ${{ inputs.from-container }}
+        INPUT_TO_CONTAINER: ${{ inputs.to-container }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "markdown<<${EOF}" >> "${GITHUB_OUTPUT}"
+        echo "$(container-size-diff.sh ${INPUT_FROM_CONTAINER} ${INPUT_TO_CONTAINER})" >> "${GITHUB_OUTPUT}"
+        echo "${EOF}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/container-size-diff/container-size-diff.sh
+++ b/.github/actions/container-size-diff/container-size-diff.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+FROM_CONTAINER=${1:?}
+TO_CONTAINER=${2:?}
+
+get_sizes_from_manifest() {
+    local CONTAINER=${1:?}
+    declare -Ag ${2:?}
+    local -n SIZE_MAP=${2}
+
+    for MANIFEST in $(docker manifest inspect -v ${CONTAINER} | jq -c 'if type == "array" then .[] else . end' | jq -r '[ ( .Descriptor.platform | [ .os, .architecture, .variant, ."os.version" ] | del(..|nulls) | join("/") ), ( [ .OCIManifest.layers[].size ] | add ) ] | join(":")');
+    do
+        PLATFORM="${MANIFEST%%:*}"
+        SIZE="${MANIFEST#*:}"
+
+        if [[ ${PLATFORM} != "unknown/unknown" ]];
+        then
+            SIZE_MAP[${PLATFORM}]=${SIZE}
+        fi
+    done
+}
+
+get_sizes_from_manifest ${FROM_CONTAINER} FROM_CONTAINER_SIZES
+get_sizes_from_manifest ${TO_CONTAINER} TO_CONTAINER_SIZES
+
+echo "## Compressed layer size comparison"
+echo
+echo "Comparing \`${FROM_CONTAINER}\` to \`${TO_CONTAINER}\`"
+echo
+echo "| OS/Platform | Previous Size | Current Size | Delta |"
+echo "|-------------|---------------|--------------|-------|"
+for PLATFORM in "${!FROM_CONTAINER_SIZES[@]}";
+do
+    BASE_SIZE=${FROM_CONTAINER_SIZES[${PLATFORM}]}
+    HEAD_SIZE=${TO_CONTAINER_SIZES[${PLATFORM}]}
+
+    echo "| ${PLATFORM} | $(numfmt --to iec --format '%.2f' ${BASE_SIZE}) | $(numfmt --to iec --format '%.2f' ${HEAD_SIZE}) | $(numfmt --to iec --format '%.2f' -- $((${HEAD_SIZE} - ${BASE_SIZE}))) $(python -c "print('({:+0.2f}%)'.format(((${HEAD_SIZE} - ${BASE_SIZE}) / ${BASE_SIZE}) * 100))") |";
+done

--- a/.github/workflows/image-build-action.yaml
+++ b/.github/workflows/image-build-action.yaml
@@ -101,14 +101,12 @@ jobs:
           GOSS_OPTS: --retry-timeout 60s --sleep 1s
         run: dgoss run ${{ steps.build.outputs.imageid }}
 
-      - if: ${{ inputs.release }}
-        name: Export Digest
+      - name: Export Digest
         id: digest
         run: |
           echo "${{ matrix.platform }}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   release:
-    if: ${{ inputs.release }}
     needs: build
     name: Release ${{ inputs.app }}
     runs-on: ubuntu-latest
@@ -181,7 +179,7 @@ jobs:
           images: >-
             ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.build.outputs.amd64 }},
             ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.build.outputs.arm64 }}
-          push: true
+          push: ${{ inputs.release }}
 
       - name: Export Digest
         id: digest
@@ -219,6 +217,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: gh attestation verify --repo ${{ github.repository }} oci://ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
+
+  pull-request-comments:
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: release
+    name: Pull Request Comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Get Container Size Diff
+        uses: ./.github/actions/container-size-diff
+        id: container-size-diff
+        with:
+          from-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:rolling
+          to-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
+
+      - name: Comment Container Size Diff
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          header: container-size-diff-${{ inputs.app }}
+          message: |
+            ${{ steps.container-size-diff.outputs.size-diff-markdown }}
 
   notify:
     if: ${{ inputs.release && !cancelled() }}

--- a/apps/jackett/metadata.yaml
+++ b/apps/jackett/metadata.yaml
@@ -1,4 +1,4 @@
 ---
 # renovate: datasource=github-releases depName=Jackett/Jackett
-version: v0.22.1685
+version: v0.22.1680
 name: jackett


### PR DESCRIPTION
Blocker: We don't know the combined docker digest for multiarch until all arch digests are [pushed to the registry](https://github.com/docker/cli/issues/3350), so having to use it in succeeding jobs is not possible when you want to do something on a pull request event. 