### PR TITLE
feat(k8s-sidecar): add new image

### DIFF
--- a/apps/k8s-sidecar/.dockerignore
+++ b/apps/k8s-sidecar/.dockerignore
@@ -1,0 +1,3 @@
+/*
+!defaults/
+!entrypoint.sh

--- a/apps/k8s-sidecar/Dockerfile
+++ b/apps/k8s-sidecar/Dockerfile
@@ -1,0 +1,15 @@
+ARG VERSION
+FROM ghcr.io/kiwigrid/k8s-sidecar:${VERSION}
+
+USER root
+
+RUN \
+    apk add --no-cache \
+        bash \
+        ca-certificates \
+        curl \
+        jq \
+        tzdata \
+    && rm -rf /tmp/*
+
+USER nobody:nogroup

--- a/apps/k8s-sidecar/docker-bake.hcl
+++ b/apps/k8s-sidecar/docker-bake.hcl
@@ -1,0 +1,33 @@
+target "docker-metadata-action" {}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=ghcr.io/kiwigrid/k8s-sidecar
+  default = "1.30.3"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "https://github.com/kiwigrid/k8s-sidecar"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/k8s-sidecar/tests.yaml
+++ b/apps/k8s-sidecar/tests.yaml
@@ -1,5 +1,5 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
 process:
-  python3:
+  python:
     running: true

--- a/apps/k8s-sidecar/tests.yaml
+++ b/apps/k8s-sidecar/tests.yaml
@@ -1,0 +1,5 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
+process:
+  python3:
+    running: true


### PR DESCRIPTION
The developer of this application is pretty derp and won't support adding in a few useful CLI tools because:

> Adding more binaries to the image does not really match the philosophy of the project having a minimal image and hence minimal attack surface.

 See here https://www.github.com/kiwigrid/k8s-sidecar/issues/271