### PR TITLE
fix(webhook): remove jsonpath bash script for now

### DIFF
--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -32,20 +32,13 @@ RUN \
         catatonit \
         coreutils \
         curl \
-        gawk \
-        grep \
         jo \
         jq \
-        sed \
         tzdata \
     && mkdir -p /app/bin \
     && \
     curl -fsSL "https://github.com/adnanh/webhook/releases/download/${VERSION}/webhook-linux-${TARGETARCH}.tar.gz" \
         | tar xzf - -C /app/bin --strip-components=1 \
-    && \
-    curl -fsSL -o /usr/local/bin/jsonpath \
-        "https://raw.githubusercontent.com/bashtools/JSONPath.sh/2e049cb3da5b7ea4a54e153f4f5246e40682f297/JSONPath.sh" \
-    && chmod +x /usr/local/bin/jsonpath \
     && \
     pip install uv \
     && uv pip install "apprise>=1, <2" \


### PR DESCRIPTION
I would like to find a replacement but jq works for now.