### PR TITLE
fix: remove jo & trurl pkgs from qb & sab [ci-skip]

### DIFF
--- a/apps/irqbalance/Dockerfile
+++ b/apps/irqbalance/Dockerfile
@@ -9,6 +9,6 @@ USER root
 RUN \
     apk add --no-cache \
         bash \
-        irqbalance="${VERSION}"
+        irqbalance=="${VERSION}"
 
 ENTRYPOINT ["/usr/sbin/irqbalance", "--foreground"]

--- a/apps/postgres-init/Dockerfile
+++ b/apps/postgres-init/Dockerfile
@@ -12,7 +12,7 @@ RUN \
         bash \
         ca-certificates \
         catatonit \
-        postgresql17-client="${VERSION}"
+        postgresql17-client=="${VERSION}"
 
 COPY . /
 

--- a/apps/qbittorrent/Dockerfile
+++ b/apps/qbittorrent/Dockerfile
@@ -24,16 +24,14 @@ RUN \
         coreutils \
         curl \
         icu-libs \
-        jo \
         jq \
         nano \
         p7zip \
         qt6-qtbase-sqlite \
-        trurl \
         tzdata \
     && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
-        qbittorrent-nox="${VERSION}" \
+        qbittorrent-nox=="${VERSION}" \
     && rm -rf /tmp/*
 
 COPY . /

--- a/apps/sabnzbd/Dockerfile
+++ b/apps/sabnzbd/Dockerfile
@@ -28,11 +28,9 @@ RUN \
         catatonit \
         coreutils \
         curl \
-        jo \
         jq \
         nano \
         p7zip \
-        trurl \
         tzdata \
     && \
     apk add --no-cache --virtual=.build-deps \

--- a/apps/transmission/Dockerfile
+++ b/apps/transmission/Dockerfile
@@ -23,10 +23,10 @@ RUN \
         jq \
         nano \
         p7zip \
-        transmission-daemon="${VERSION}" \
-        transmission-cli \
-        transmission-extra \
-        transmission-remote \
+        transmission-daemon=="${VERSION}" \
+        transmission-cli=="${VERSION}" \
+        transmission-extra=="${VERSION}" \
+        transmission-remote=="${VERSION}" \
         tzdata \
     && \
     case "${TARGETPLATFORM}" in \


### PR DESCRIPTION
- remove jo & trurl pkgs from qb & sab
- use double equal operator for installing alpine pkgs