### PR TITLE
fix(home-assistant): Add mailcap to install /etc/mime.types for proper tts proxy support

### DIFF
--- a/apps/home-assistant/Dockerfile
+++ b/apps/home-assistant/Dockerfile
@@ -48,6 +48,7 @@ RUN \
         libpcap-dev \
         libstdc++ \
         libxslt \
+        mailcap \
         mariadb-connector-c \
         mariadb-connector-c-dev \
         nano \


### PR DESCRIPTION
Noticed that with the Home Assistant Voice Preview that without the mim.types the response playback fails.  See this issue: https://github.com/esphome/home-assistant-voice-pe/issues/378#issuecomment-2783815609