### PR TITLE
feat(deluge): revert allow port customizations

### DIFF
--- a/apps/deluge/Dockerfile
+++ b/apps/deluge/Dockerfile
@@ -7,8 +7,6 @@ ENV UMASK="0002" \
     TZ="Etc/UTC"
 
 ENV DELUGE_BIN="deluged" \
-    DELUGE_WEB_PORT="8112" \
-    DELUGE_DAEMON_PORT="58846" \
     XDG_CONFIG_HOME="/config" \
     PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 

--- a/apps/deluge/entrypoint.sh
+++ b/apps/deluge/entrypoint.sh
@@ -3,23 +3,19 @@
 
 if [[ ! -f /config/core.conf ]]; then
     cp /defaults/core.conf /config/core.conf
-    sed -i -e "s/58846/${DELUGE_DAEMON_PORT:-58846}/" /config/core.conf
 fi
 
 mkdir -p /config/plugins/.python-eggs
 
-OPTS=(
+DELUGE_OPTS=(
     "--do-not-daemonize"
     "--config" "/config"
-    "--loglevel" "${DELUGE_LOGLEVEL:-info}"
-    "--interface" "0.0.0.0"
 )
 
-if [[ ${DELUGE_BIN:-deluged} == "deluged" ]]; then
-    OPTS+=("--ui-interface" "0.0.0.0")
-    OPTS+=("--port" "${DELUGE_DAEMON_PORT:-58846}")
-elif [[ ${DELUGE_BIN:-deluged} == "deluge-web" ]]; then
-    OPTS+=("--port" "${DELUGE_WEB_PORT:-8112}")
+if [[ ${DELUGE_BIN} == "deluged" ]]; then
+    DELUGE_OPTS+=("--loglevel" "info")
+elif [[ ${DELUGE_BIN} == "deluge-web" ]]; then
+    DELUGE_OPTS+=("--loglevel" "warning")
 fi
 
-exec ${DELUGE_BIN:-deluged} "${OPTS[@]}" "$@"
+exec ${DELUGE_BIN} "${DELUGE_OPTS[@]}" "$@"


### PR DESCRIPTION
Adds too much jank to the entrypoint since the args do not get auto updated in the config files