### PR TITLE
fix(qb): do not set ports as env

### DIFF
--- a/apps/qbittorrent/Dockerfile
+++ b/apps/qbittorrent/Dockerfile
@@ -7,8 +7,6 @@ ENV UMASK="0002" \
     TZ="Etc/UTC"
 
 ENV QBT_CONFIRM_LEGAL_NOTICE=1 \
-    QBT_WEBUI_PORT=8080 \
-    QBT_TORRENTING_PORT=50413 \
     HOME="/config" \
     XDG_CONFIG_HOME="/config" \
     XDG_DATA_HOME="/config"

--- a/apps/qbittorrent/defaults/qBittorrent.conf
+++ b/apps/qbittorrent/defaults/qBittorrent.conf
@@ -14,6 +14,7 @@ Session\DiskIOWriteMode=EnableOSCache
 Session\DiskQueueSize=4194304
 Session\FilePoolSize=40
 Session\HashingThreadsCount=2
+Session\Port=50413
 Session\ResumeDataStorageType=SQLite
 Session\UseOSCache=true
 
@@ -26,5 +27,6 @@ WebUI\Address=*
 WebUI\CSRFProtection=false
 WebUI\HostHeaderValidation=false
 WebUI\LocalHostAuth=false
+WebUI\Port=8080
 WebUI\ServerDomains=*
 WebUI\UseUPnP=false


### PR DESCRIPTION
Due to the nature of changing config options in the UI, it is not best to have these env defaulted in the container.

This is not a breaking change as anyone who deployed QB without any env set their config file holds the ports being used.

Fixes #362 