### PR TITLE
fix(beets): use latest nodejs

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -73,12 +73,5 @@
       matchPackageNames: ["/python/"],
       allowedVersions: "/3\\.12/",
     },
-    {
-      description: ["Allowed Node Version for Beets"],
-      matchDatasources: ["docker"],
-      matchFileNames: ["apps/beets/Dockerfile"],
-      matchPackageNames: ["/node/"],
-      allowedVersions: "/16-alpine3\\.18/",
-    },
   ],
 }

--- a/apps/beets/Dockerfile
+++ b/apps/beets/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/node:16-alpine3.18 AS betanin
+FROM docker.io/library/node:22-alpine AS betanin
 WORKDIR /src
 ADD https://github.com/sentriz/betanin.git .
 WORKDIR /src/betanin_client
 ENV PRODUCTION=true
+ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN npm install && npm run-script build
 
 FROM docker.io/library/python:3.12-alpine
@@ -58,8 +59,10 @@ RUN \
     apk add --no-cache --virtual=.build-deps \
         git \
     && \
-    apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/edge/testing/" \
+    apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/edge/community/" \
         mp3gain \
+    && \
+    apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/edge/testing/" \
         mp3val \
     && \
     pip install uv \


### PR DESCRIPTION
Found a way around the build errors when using Node v22 (LTS)