### PR TITLE
feat(deluge): update to v2.2.0

### DIFF
--- a/apps/deluge/Dockerfile
+++ b/apps/deluge/Dockerfile
@@ -20,13 +20,15 @@ RUN \
         jq \
         nano \
         p7zip \
+        py3-future \
+        py3-requests \
         tzdata \
     && \
-    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing \
+    apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/edge/community" \
         deluge=="${VERSION}" \
-        py3-future \
+    && \
+    apk add --no-cache --repository="https://dl-cdn.alpinelinux.org/alpine/edge/testing" \
         py3-geoip \
-        py3-requests \
     && \
     mkdir -p /usr/share/GeoIP \
     && \

--- a/apps/deluge/docker-bake.hcl
+++ b/apps/deluge/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 
 variable "VERSION" {
   // renovate: datasource=repology depName=alpine_edge/deluge
-  default = "2.1.1-r10"
+  default = "2.2.0-r0"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Repology datasource looks broken, no updates were discovered.