### PR TITLE
ci: use a common dockerignore for all containers [ci-skip]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+# NOTE: This file automatically copied to
+# each container directory during build
 /*
 !defaults/
 !scripts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /*
 !defaults/
+!scripts/
 !entrypoint.sh

--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -112,6 +112,10 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Setup Docker Ignore
+        run: |
+          cp .dockerignore ./apps/${{ inputs.app }}/.dockerignore
+
       - name: Build Application
         uses: docker/bake-action@76f9fa3a758507623da19f6092dc4089a7e61592 # v6.6.0
         id: bake

--- a/apps/atuin-server-sqlite/.dockerignore
+++ b/apps/atuin-server-sqlite/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/bazarr/.dockerignore
+++ b/apps/bazarr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/beets/.dockerignore
+++ b/apps/beets/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/cni-plugins/.dockerignore
+++ b/apps/cni-plugins/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/deluge/.dockerignore
+++ b/apps/deluge/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/emby/.dockerignore
+++ b/apps/emby/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/esphome/.dockerignore
+++ b/apps/esphome/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/home-assistant/.dockerignore
+++ b/apps/home-assistant/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/irqbalance/.dockerignore
+++ b/apps/irqbalance/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/it-tools/.dockerignore
+++ b/apps/it-tools/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/jackett/.dockerignore
+++ b/apps/jackett/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/jbops/.dockerignore
+++ b/apps/jbops/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/k8s-sidecar/.dockerignore
+++ b/apps/k8s-sidecar/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/lidarr/.dockerignore
+++ b/apps/lidarr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/nzbget/.dockerignore
+++ b/apps/nzbget/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/opentofu-runner/.dockerignore
+++ b/apps/opentofu-runner/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/plex/.dockerignore
+++ b/apps/plex/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/postgres-init/.dockerignore
+++ b/apps/postgres-init/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/prowlarr/.dockerignore
+++ b/apps/prowlarr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/qbittorrent/.dockerignore
+++ b/apps/qbittorrent/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/radarr/.dockerignore
+++ b/apps/radarr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/readarr/.dockerignore
+++ b/apps/readarr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/sabnzbd/.dockerignore
+++ b/apps/sabnzbd/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/smartctl-exporter/.dockerignore
+++ b/apps/smartctl-exporter/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/sonarr/.dockerignore
+++ b/apps/sonarr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/tautulli/.dockerignore
+++ b/apps/tautulli/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/theme-park/.dockerignore
+++ b/apps/theme-park/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/transmission/.dockerignore
+++ b/apps/transmission/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/volsync/.dockerignore
+++ b/apps/volsync/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/webhook/.dockerignore
+++ b/apps/webhook/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh

--- a/apps/whisparr/.dockerignore
+++ b/apps/whisparr/.dockerignore
@@ -1,3 +1,0 @@
-/*
-!defaults/
-!entrypoint.sh


### PR DESCRIPTION
Clean up some duplication by using a common dockerignore for all container images