### PR TITLE
fix: switch from p7zip to 7zip

### DIFF
--- a/apps/deluge/Dockerfile
+++ b/apps/deluge/Dockerfile
@@ -12,6 +12,7 @@ USER root
 
 RUN \
     apk add --no-cache \
+        7zip \
         bash \
         ca-certificates \
         catatonit \
@@ -19,7 +20,6 @@ RUN \
         curl \
         jq \
         nano \
-        p7zip \
         py3-future \
         py3-requests \
         tzdata \

--- a/apps/qbittorrent/Dockerfile
+++ b/apps/qbittorrent/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 RUN \
     apk add --no-cache \
+        7zip \
         bash \
         ca-certificates \
         catatonit \
@@ -23,7 +24,6 @@ RUN \
         curl \
         jq \
         nano \
-        p7zip \
         tzdata \
     && \
     mkdir -p /app \

--- a/apps/transmission/Dockerfile
+++ b/apps/transmission/Dockerfile
@@ -14,6 +14,7 @@ ENV HOME="/config" \
 
 RUN \
     apk add --no-cache \
+        7zip \
         bash \
         ca-certificates \
         catatonit \
@@ -21,7 +22,6 @@ RUN \
         curl \
         jq \
         nano \
-        p7zip \
         transmission-daemon=="${VERSION}" \
         transmission-cli=="${VERSION}" \
         transmission-extra=="${VERSION}" \


### PR DESCRIPTION
Alpine no longer provides p7zip, it just links to 7zip so might as well use the actual package name that is installed.