### PR TITLE
fix: pin alpine and python versions across all apps [ci-skip]

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -71,11 +71,25 @@
       allowedVersions: "/24\\.04/",
     },
     {
+      description: ["Allowed Alpine Version"],
+      matchDatasources: ["docker"],
+      matchFileNames: ["**/Dockerfile"],
+      matchPackageNames: ["/alpine/"],
+      allowedVersions: "/3\\.21/",
+    },
+    {
+      description: ["Allowed Python Version"],
+      matchDatasources: ["docker"],
+      matchFileNames: ["**/Dockerfile"],
+      matchPackageNames: ["/python/"],
+      allowedVersions: "/3\\.13-alpine3\\.21/",
+    },
+    {
       description: ["Allowed Python Version for Bazarr"],
       matchDatasources: ["docker"],
       matchFileNames: ["apps/bazarr/Dockerfile"],
       matchPackageNames: ["/python/"],
-      allowedVersions: "/3\\.12/",
+      allowedVersions: "/3\\.12-alpine3\\.21//",
     },
   ],
 }

--- a/apps/bazarr/Dockerfile
+++ b/apps/bazarr/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.12-alpine
+FROM docker.io/library/python:3.12-alpine3.21
 ARG VENDOR
 ARG VERSION
 

--- a/apps/beets/Dockerfile
+++ b/apps/beets/Dockerfile
@@ -8,7 +8,7 @@ ENV PRODUCTION=true
 ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN npm install && npm run-script build
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG VERSION
 
 WORKDIR /src

--- a/apps/esphome/Dockerfile
+++ b/apps/esphome/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG VERSION
 
 ENV \

--- a/apps/jbops/Dockerfile
+++ b/apps/jbops/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG VERSION
 
 ENV \

--- a/apps/nzbget/Dockerfile
+++ b/apps/nzbget/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG VERSION
 
 ENV \

--- a/apps/qbittorrent/Dockerfile
+++ b/apps/qbittorrent/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG TARGETARCH
 ARG TARGETARCH=${TARGETARCH/arm64/aarch64}
 ARG TARGETARCH=${TARGETARCH/amd64/x86_64}

--- a/apps/sabnzbd/Dockerfile
+++ b/apps/sabnzbd/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG VERSION
 
 ENV \

--- a/apps/tautulli/Dockerfile
+++ b/apps/tautulli/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG VERSION
 
 ENV \

--- a/apps/theme-park/Dockerfile
+++ b/apps/theme-park/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine AS builder
+FROM docker.io/library/python:3.13-alpine3.21 AS builder
 ARG VERSION
 RUN \
     apk add --no-cache \

--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine
+FROM docker.io/library/python:3.13-alpine3.21
 ARG TARGETARCH
 ARG VERSION
 


### PR DESCRIPTION
When a new major version of python or alpine are released, we need to be careful as these updates might break builds. This PR essentially makes updating python or alpine versions a manual task across all apps.

We need to be careful when new major versions are released for those base images.