### PR TITLE
✨🐘 feat(postgres-init): Add support for UTF-8 database creation

### DIFF
--- a/apps/postgres-init/entrypoint.sh
+++ b/apps/postgres-init/entrypoint.sh
@@ -3,7 +3,7 @@
 # This is most commonly set to the user 'postgres'
 export INIT_POSTGRES_SUPER_USER=${INIT_POSTGRES_SUPER_USER:-postgres}
 export INIT_POSTGRES_PORT=${INIT_POSTGRES_PORT:-5432}
-export INIT_POSTGRES_UTF8=${INIT_POSTGRES_UTF8:-""}
+export INIT_POSTGRES_UTF8=${INIT_POSTGRES_UTF8:-"false"}
 
 if [[ -z "${INIT_POSTGRES_HOST}"       ||
       -z "${INIT_POSTGRES_SUPER_PASS}" ||
@@ -54,11 +54,11 @@ for dbname in ${INIT_POSTGRES_DBNAME}; do
             --command "SELECT 1 FROM pg_database WHERE datname = '${dbname}'"
     )
     if [[ -z "${database_exists}" ]]; then
-        printf "\e[1;32m%-6s\e[m\n" "Create Database ${dbname} ..."
-        if [ "$INIT_POSTGRES_UTF8" = "true" ]; then
-            echo "Creating database ${dbname} with UTF8 encoding..."
-            createdb -T template0 -E UTF8 --owner "${INIT_POSTGRES_USER}" "${dbname}" 
+        if [[ "${INIT_POSTGRES_UTF8}" == "true" ]]; then
+            printf "\e[1;32m%-6s\e[m\n" "Create Database ${dbname} with UTF8 encoding ..."
+            createdb --template template0 --encoding UTF8 --owner "${INIT_POSTGRES_USER}" "${dbname}" 
         else
+            printf "\e[1;32m%-6s\e[m\n" "Create Database ${dbname} ..."
             createdb --owner "${INIT_POSTGRES_USER}" "${dbname}" 
         fi
         database_init_file="/initdb/${dbname}.sql"

--- a/apps/postgres-init/entrypoint.sh
+++ b/apps/postgres-init/entrypoint.sh
@@ -3,6 +3,7 @@
 # This is most commonly set to the user 'postgres'
 export INIT_POSTGRES_SUPER_USER=${INIT_POSTGRES_SUPER_USER:-postgres}
 export INIT_POSTGRES_PORT=${INIT_POSTGRES_PORT:-5432}
+export INIT_POSTGRES_UTF8=${INIT_POSTGRES_UTF8:-""}
 
 if [[ -z "${INIT_POSTGRES_HOST}"       ||
       -z "${INIT_POSTGRES_SUPER_PASS}" ||
@@ -54,7 +55,12 @@ for dbname in ${INIT_POSTGRES_DBNAME}; do
     )
     if [[ -z "${database_exists}" ]]; then
         printf "\e[1;32m%-6s\e[m\n" "Create Database ${dbname} ..."
-        createdb --owner "${INIT_POSTGRES_USER}" "${dbname}"
+        if [ "$INIT_POSTGRES_UTF8" = "true" ]; then
+            echo "Creating database ${dbname} with UTF8 encoding..."
+            createdb -T template0 -E UTF8 --owner "${INIT_POSTGRES_USER}" "${dbname}" 
+        else
+            createdb --owner "${INIT_POSTGRES_USER}" "${dbname}" 
+        fi
         database_init_file="/initdb/${dbname}.sql"
         if [[ -f "${database_init_file}" ]]; then
             printf "\e[1;32m%-6s\e[m\n" "Initialize Database ..."


### PR DESCRIPTION
This pull request adds a new configuration option to the apps/postgres-init/entrypoint.sh script, enabling the creation of databases with UTF8 encoding when specified. These changes improve flexibility during database initialization.

If the environment variable INIT_POSTGRES_UTF8 is not set, the initial database script retains its previous behavior.

The INIT_POSTGRES_UTF8 variable only accepts the value "true" to enable UTF8 encoding.