### PR TITLE
SABnzbd: Enable file logging

### DIFF
--- a/apps/sabnzbd/entrypoint.sh
+++ b/apps/sabnzbd/entrypoint.sh
@@ -23,6 +23,5 @@ exec \
         --browser 0 \
         --server ${SABNZBD__ADDRESS}:${SABNZBD__PORT} \
         --config-file /config/sabnzbd.ini \
-        --disable-file-log \
         --console \
         "$@"


### PR DESCRIPTION
File logging is important for the "Show Logging" function which generates a sanitised log (which is needed for troubleshooting); the actual console message wouldn't be sanitised.

References: https://github.com/truenas/apps/issues/2702, https://github.com/sabnzbd/sabnzbd/issues/3107