### PR TITLE
ci: post the container size diff to the pull request

### DIFF
--- a/.github/actions/app-tests/run.sh
+++ b/.github/actions/app-tests/run.sh
@@ -5,6 +5,7 @@ APP="${1:?}"
 IMAGE="${2:?}"
 
 if [[ -x "$(command -v container-structure-test)" ]]; then
+    docker pull "${IMAGE}"
     container-structure-test test --image "${IMAGE}" --config "./apps/${APP}/tests.yaml"
 elif [[ -x "$(command -v goss)" && -x "$(command -v dgoss)" ]]; then
     export GOSS_FILE="./apps/${APP}/tests.yaml"

--- a/.github/actions/app-tests/run.sh
+++ b/.github/actions/app-tests/run.sh
@@ -5,8 +5,7 @@ APP="${1:?}"
 IMAGE="${2:?}"
 
 if [[ -x "$(command -v container-structure-test)" ]]; then
-    docker pull "${IMAGE}"
-    container-structure-test test --image "${IMAGE}" --config "./apps/${APP}/tests.yaml"
+    container-structure-test test --image "${IMAGE}" --pull --config "./apps/${APP}/tests.yaml"
 elif [[ -x "$(command -v goss)" && -x "$(command -v dgoss)" ]]; then
     export GOSS_FILE="./apps/${APP}/tests.yaml"
     export GOSS_OPTS="--retry-timeout 60s --sleep 1s"

--- a/.github/actions/container-size-diff/action.yaml
+++ b/.github/actions/container-size-diff/action.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+name: Container Size Diff
+description: Creates a Markdown summary of the size difference between two container versions
+
+inputs:
+  from-container:
+    description: Baseline container image for size comparison
+    required: true
+  to-container:
+    description: Container image to be compared to the baseline
+    required: true
+
+outputs:
+  size-diff-markdown:
+    description: Markdown formatted output of container size comparison
+    value: ${{ steps.size-diff.outputs.markdown }}
+
+runs:
+  using: composite
+  steps:
+    - name: container-size-diff
+      id: size-diff
+      shell: bash
+      env:
+        INPUT_FROM_CONTAINER: ${{ inputs.from-container }}
+        INPUT_TO_CONTAINER: ${{ inputs.to-container }}
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "markdown<<${EOF}" >> "${GITHUB_OUTPUT}"
+        echo "$(${GITHUB_ACTION_PATH}/container-size-diff.sh ${INPUT_FROM_CONTAINER} ${INPUT_TO_CONTAINER})" >> "${GITHUB_OUTPUT}"
+        echo "${EOF}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/container-size-diff/container-size-diff.sh
+++ b/.github/actions/container-size-diff/container-size-diff.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FROM_CONTAINER=${1:?}
+TO_CONTAINER=${2:?}
+
+format_size() {
+    local SIZE=${1:?}
+
+    numfmt --to iec --format '%.2f' -- "${SIZE}"
+}
+
+get_sizes_from_manifest() {
+    local CONTAINER=${1:?}
+    declare -Ag ${2:?}
+    local -n SIZE_MAP=${2}
+
+    for MANIFEST in $(docker manifest inspect -v ${CONTAINER} | jq -c 'if type == "array" then .[] else . end' | jq -r '[ ( .Descriptor.platform | [ .os, .architecture, .variant, ."os.version" ] | del(..|nulls) | join("/") ), ( [ .OCIManifest.layers[].size ] | add ) ] | join(":")');
+    do
+        PLATFORM="${MANIFEST%%:*}"
+        SIZE="${MANIFEST#*:}"
+
+        if [[ ${PLATFORM} != "unknown/unknown" ]];
+        then
+            SIZE_MAP[${PLATFORM}]=${SIZE}
+        fi
+    done
+}
+
+get_sizes_from_manifest ${FROM_CONTAINER} FROM_CONTAINER_SIZES
+get_sizes_from_manifest ${TO_CONTAINER} TO_CONTAINER_SIZES
+
+echo "## 📦 Container Size Analysis"
+echo
+echo "Comparing \`${FROM_CONTAINER}\` to \`${TO_CONTAINER}\`"
+echo
+
+echo "### 📈 Size Comparison Table"
+echo
+echo "| OS/Platform | Previous Size | Current Size | Change | Trend |"
+echo "|-------------|:-------------:|:------------:|:------:|:-----:|"
+
+for PLATFORM in "${!FROM_CONTAINER_SIZES[@]}";
+do
+    FROM_SIZE=${FROM_CONTAINER_SIZES[${PLATFORM}]:0}
+    TO_SIZE=${TO_CONTAINER_SIZES[${PLATFORM}]:0}
+    DELTA=$((${TO_SIZE} - ${FROM_SIZE}))
+
+    if [[ ${FROM_SIZE} -eq 0 ]]; then
+        # If from size was 0, and there's a change, that's infinite percentage change
+        if [[ ${TO_SIZE} -gt 0 ]]; then
+            PERCENT_CHANGE="+∞"
+        else
+            PERCENT_CHANGE="+0.00"
+        fi
+    else
+        PERCENT_CHANGE=$(awk -v to="${TO_SIZE}" -v from="${FROM_SIZE}" 'BEGIN { printf "%+0.2f", ((to - from) / from) * 100 }')
+    fi
+
+    if (( DELTA < 0 )); then
+        ICON="🔽"
+    elif (( DELTA > 0 )); then
+        ICON="🔼"
+    else
+        ICON="🔄"
+    fi
+
+    echo "| ${PLATFORM} | $(format_size ${FROM_SIZE}) | $(format_size ${TO_SIZE}) | $(format_size ${DELTA}) (${PERCENT_CHANGE}%) | ${ICON} |"
+done

--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -229,14 +229,14 @@ jobs:
           image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.merge.outputs.digest }}
           token: ${{ github.token }}
 
-      - name: Container Size Diff
+      - name: Get Container Size Diff
         uses: ./.github/actions/container-size-diff
         id: container-size-diff
         with:
           from-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:rolling
           to-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:sandbox
 
-      - name: Post Container Size Diff Comment
+      - name: Post Container Size Diff
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -166,13 +166,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Generate Token
-        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
-        id: app-token
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-
       - name: Download Bake Metadata
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -211,23 +204,6 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:${TAG} --format '{{ json . }}' | jq --raw-output '.manifest.digest')
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
-      - if: ${{ ! inputs.release }}
-        name: Container Size Diff
-        uses: ./.github/actions/container-size-diff
-        id: container-size-diff
-        with:
-          from-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:rolling
-          to-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:sandbox
-
-      - if: ${{ ! inputs.release }}
-        name: Post Container Size Diff Comment
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          header: container-size-diff-${{ inputs.app }}
-          message: |
-            ${{ steps.container-size-diff.outputs.size-diff-markdown }}
-
   test:
     if: ${{ ! inputs.release }}
     name: Test
@@ -239,12 +215,34 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Generate Token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Run Application Tests
         uses: ./.github/actions/app-tests
         with:
           app: ${{ inputs.app }}
           image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.merge.outputs.digest }}
           token: ${{ github.token }}
+
+      - name: Container Size Diff
+        uses: ./.github/actions/container-size-diff
+        id: container-size-diff
+        with:
+          from-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:rolling
+          to-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:sandbox
+
+      - name: Post Container Size Diff Comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          header: container-size-diff-${{ inputs.app }}
+          message: |
+            ${{ steps.container-size-diff.outputs.size-diff-markdown }}
 
   attest:
     name: Attest

--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -55,11 +55,12 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.app-versions.outputs.semantic }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.app-versions.outputs.semantic }},enable=${{ steps.app-versions.outputs.is-valid-semver }}
-            type=semver,pattern={{major}},value=${{ steps.app-versions.outputs.semantic }},enable=${{ steps.app-versions.outputs.is-valid-semver }}
-            type=raw,value=${{ steps.app-versions.outputs.raw }},enable=${{ steps.app-versions.outputs.is-valid-semver }}
-            type=raw,value=rolling
+            type=semver,pattern={{version}},value=${{ steps.app-versions.outputs.semantic }},enable=${{ steps.app-versions.outputs.is-valid-semver && inputs.release }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.app-versions.outputs.semantic }},enable=${{ steps.app-versions.outputs.is-valid-semver && inputs.release }}
+            type=semver,pattern={{major}},value=${{ steps.app-versions.outputs.semantic }},enable=${{ steps.app-versions.outputs.is-valid-semver && inputs.release }}
+            type=raw,value=${{ steps.app-versions.outputs.raw }},enable=${{ steps.app-versions.outputs.is-valid-semver && inputs.release }}
+            type=raw,value=rolling,enable=${{ inputs.release }}
+            type=raw,value=sandbox,enable=${{ ! inputs.release }}
 
       - name: Upload Bake Metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -132,30 +133,20 @@ jobs:
             *.labels.org.opencontainers.image.version=${{ steps.app-options.outputs.version }}
             *.labels.org.opencontainers.image.revision=${{ github.sha }}
             *.labels.org.opencontainers.image.vendor=${{ github.repository_owner }}
-            ${{ inputs.release && format('*.output=type=image,name=ghcr.io/{0}/{1},push-by-digest=true,name-canonical=true,push=true,compression=zstd,force-compression=true', github.repository_owner, inputs.app) || '*.output=type=docker' }}
+            *.output=type=image,name=ghcr.io/${{ github.repository_owner }}/${{ inputs.app }},push-by-digest=true,name-canonical=true,push=true,compression=zstd,force-compression=true
             *.platform=${{ matrix.platform }}
             *.tags=
           source: .
           targets: image
           workdir: ./apps/${{ inputs.app }}
 
-      - if: ${{ ! inputs.release }}
-        name: Run Application Tests
-        uses: ./.github/actions/app-tests
-        with:
-          app: ${{ inputs.app }}
-          image: ${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.config.digest'] }}
-          token: ${{ github.token }}
-
-      - if: ${{ inputs.release }}
-        name: Export Digest
+      - name: Export Digest
         run: |
           mkdir -p ${{ runner.temp }}/digests
           DIGEST="${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}"
           touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
-      - if: ${{ inputs.release }}
-        name: Upload Digest
+      - name: Upload Digest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.app }}-digests-${{ steps.target.outputs.arch }}
@@ -163,9 +154,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  release:
-    if: ${{ inputs.release }}
-    name: Release
+  merge:
+    name: Merge
     runs-on: ubuntu-latest
     needs: ["build"]
     outputs:
@@ -175,6 +165,13 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+
+      - name: Generate Token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Download Bake Metadata
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -214,10 +211,44 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:${TAG} --format '{{ json . }}' | jq --raw-output '.manifest.digest')
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
 
+      - if: ${{ ! inputs.release }}
+        name: Container Size Diff
+        uses: ./.github/actions/container-size-diff
+        id: container-size-diff
+        with:
+          from-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:rolling
+          to-container: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:sandbox
+
+      - if: ${{ ! inputs.release }}
+        name: Post Container Size Diff Comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          header: container-size-diff-${{ inputs.app }}
+          message: |
+            ${{ steps.container-size-diff.outputs.size-diff-markdown }}
+
+  test:
+    if: ${{ ! inputs.release }}
+    name: Test
+    needs: ["merge"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Application Tests
+        uses: ./.github/actions/app-tests
+        with:
+          app: ${{ inputs.app }}
+          image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.merge.outputs.digest }}
+          token: ${{ github.token }}
+
   attest:
-    if: ${{ inputs.release }}
     name: Attest
-    needs: ["release"]
+    needs: ["merge"]
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
@@ -231,20 +262,20 @@ jobs:
         uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
         with:
           dependency-snapshot: true
-          image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
+          image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.merge.outputs.digest }}
 
       - name: Attestation
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           push-to-registry: true
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}
-          subject-digest: ${{ needs.release.outputs.digest }}
+          subject-digest: ${{ needs.merge.outputs.digest }}
 
       - name: Verify Attestation
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh attestation verify --repo ${{ github.repository }} oci://ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.release.outputs.digest }}
+          gh attestation verify --repo ${{ github.repository }} oci://ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}@${{ needs.merge.outputs.digest }}
 
   announce:
     if: ${{ inputs.release && needs.plan.outputs.app-exists != 'true' }}
@@ -292,7 +323,7 @@ jobs:
 
   notify:
     if: ${{ inputs.release && !cancelled() }}
-    needs: ["plan", "build", "release", "attest", "announce"]
+    needs: ["plan", "build", "merge", "attest", "announce"]
     name: Notify
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -27,8 +27,10 @@ jobs:
     needs: ["prepare"]
     uses: ./.github/workflows/app-builder.yaml
     permissions:
+      attestations: write
       contents: read
-      packages: read
+      id-token: write
+      packages: write
     secrets: inherit
     strategy:
       matrix:


### PR DESCRIPTION
Support posting a container diff of the new image and previous image. Kindly "inspired" by https://github.com/philips-software/amp-devcontainer/tree/09d0fb4c4601281473bed279fca0d66bf52a26e0/.github/actions/container-size-diff

Some changes needed to be made for this to happen...

1. Push tags for PR builds under a mutable `:sandbox` tag
2. Move testing container to it's own job stage which references the `:sandbox` tag

Benefits:

1. See size diffs of the container in the PR.
2. Test built images in $prod before they are merged.

Drawbacks:

1. Some glue, some maintenance.