### PR TITLE
fix(cni-plugins): exclude `LICENSE` and `README.md` from installation

### DIFF
--- a/apps/cni-plugins/Dockerfile
+++ b/apps/cni-plugins/Dockerfile
@@ -21,4 +21,4 @@ RUN \
     && apk del --purge .build-deps \
     && rm -rf  /tmp/*
 
-CMD rsync -av /plugins/* $CNI_BIN_DIR
+CMD rsync -av --exclude=LICENSE --exclude=README.md /plugins/* $CNI_BIN_DIR


### PR DESCRIPTION
Noticed these files in the release tarball and figured that there's no reason to copy them to the CNI bin directory.