### PR TITLE
add pyload-ng container

### DIFF
--- a/apps/pyload-ng/Dockerfile
+++ b/apps/pyload-ng/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/python:3.13-alpine3.22
+ARG VERSION
+
+ENV \
+    CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
+    PIP_BREAK_SYSTEM_PACKAGES=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_NO_CACHE=true \
+    UV_SYSTEM_PYTHON=true \
+    UV_EXTRA_INDEX_URL="https://wheel-index.linuxserver.io/alpine-3.22/"
+
+ENV HOME="/config"
+
+USER root
+WORKDIR /app
+
+RUN \
+    apk add --no-cache --virtual=build-dependencies \
+        build-base \
+        curl-dev \
+    && apk add --no-cache \
+        catatonit \
+        ffmpeg \
+        libatomic \
+        libcurl \
+        libjpeg-turbo \
+        7zip \
+        sqlite \
+        tesseract-ocr \
+    && pip install --no-cache-dir uv \
+    && uv pip install --pre pyload-ng[all]=="${VERSION}" \
+    && mkdir -p /config && chown nobody:nogroup -R /config \
+    && mkdir -p /downloads && chown nobody:nogroup -R /downloads \
+    && apk del --purge build-dependencies \
+    && rm -rf /root/.cache /tmp/*
+
+COPY . /
+
+COPY --from=ghcr.io/linuxserver/unrar:latest /usr/bin/unrar-alpine /usr/bin/unrar
+
+USER nobody:nogroup
+WORKDIR /config
+
+VOLUME ["/config"]
+
+ENTRYPOINT ["/usr/bin/catatonit", "--", "/entrypoint.sh"]

--- a/apps/pyload-ng/defaults/pyload.cfg
+++ b/apps/pyload-ng/defaults/pyload.cfg
@@ -1,0 +1,74 @@
+version: 2
+
+download - "Download":
+        int chunks : "Maximum connections for one download" = 3
+        time end_time : "End time" = 0:00
+        ip interface : "Download interface to bind (IP Address)" =
+        bool ipv6 : "Allow IPv6" = False
+        bool limit_speed : "Limit download speed" = False
+        int max_downloads : "Maximum parallel downloads" = 3
+        int max_speed : "Maximum download speed in KiB/s" = -1
+        bool skip_existing : "Skip already existing files" = False
+        time start_time : "Start time" = 0:00
+
+general - "General":
+        debug;trace;stack debug_level : "Debug level" = trace
+        bool debug_mode : "Debug mode" = True
+        bool folder_per_package : "Create folder for each package" = True
+        en; language : "Language" = en
+        int min_free_space : "Minimum free space in MiB" = 1024
+        bool ssl_verify : "Verify SSL certificates" = True
+        folder storage_folder : "Download folder" = /downloads
+
+log - "Log":
+        bool console : "Print log to console" = True
+        bool console_color : "Colorize console" = False
+        bool filelog : "Save log to file" = True
+        int filelog_entries : "Maximum log files" = 10
+        folder filelog_folder : "Log file folder" =
+        bool filelog_rotate : "Log rotate" = True
+        int filelog_size : "Maximum file size (in KiB)" = 5120
+        bool syslog : "Sent log to syslog" = False
+        folder syslog_folder : "Syslog local folder" =
+        ip syslog_host : "Syslog remote IP address" = localhost
+        local;remote syslog_location : "Syslog location" = local
+        int syslog_port : "Syslog remote port" = 514
+
+permission - "Permissions":
+        bool change_dl : "Change ownership of downloads" = False
+        bool change_file : "Change permissions of downloads" = False
+        bool change_group : "Change group of running process" = False
+        bool change_user : "Change user of running process" = False
+        str file : "Permission mode for downloaded files" = 0644
+        str folder : "Permission mode for created folders" = 0755
+        str group : "Groupname for ownership" = users
+        str user : "Username for ownership" = user
+
+proxy - "Proxy":
+        bool enabled : "Activated" = False
+        ip host : "IP address" = localhost
+        password password : "Password" =
+        int port : "Port" = 7070
+        bool socks_resolve_dns : "Enable DNS resolution through SOCKS proxy" = False
+        http;https;socks4;socks5 type : "Protocol" = http
+        str username : "Username" =
+
+reconnect - "Reconnection":
+        bool enabled : "Activated" = False
+        time end_time : "End time" = 0:00
+        str script : "Script" =
+        time start_time : "Start time" = 0:00
+
+webui - "Web Interface":
+        bool autologin : "Skip login if single user" = False
+        bool develop : "Development mode" = False
+        bool enabled : "Activated" = True
+        ip host : "IP address" = 0.0.0.0
+        int port : "Port" = 8000
+        str prefix : "Path prefix" =
+        int session_lifetime : "Session lifetime (minutes)" = 44640
+        file ssl_certchain : "CA's intermediate certificate bundle (optional)" =
+        file ssl_certfile : "SSL Certificate" = /config/data/ssl.crt
+        file ssl_keyfile : "SSL Key" = /config/data/ssl.key
+        Default;modern;pyplex theme : "Theme" = modern
+        bool use_ssl : "Use HTTPS" = False

--- a/apps/pyload-ng/docker-bake.hcl
+++ b/apps/pyload-ng/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "pyload-ng"
+}
+
+variable "VERSION" {
+  // renovate: datasource=pypi depName=pyload-ng
+  default = "0.5.0b3.dev93"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/pyload/pyload"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/pyload-ng/entrypoint.sh
+++ b/apps/pyload-ng/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+if [ ! -f /config/settings/pyload.cfg ]; then
+    mkdir /config/settings
+    cp /defaults/pyload.cfg /config/settings/pyload.cfg
+fi
+
+exec \
+    python3 -m pyload \
+        --userdir /config \
+        --storagedir /downloads \
+        --tempdir /tmp/pyload \
+        "$@"

--- a/apps/pyload-ng/tests.yaml
+++ b/apps/pyload-ng/tests.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
+process:
+  python3:
+    running: true
+file:
+  /usr/local/bin/pyload:
+    exists: true
+port:
+  tcp6:8000:
+    listening: true
+  tcp6:9666:
+    listening: true
+http:
+  http://localhost:8000:
+    status: 200

--- a/apps/pyload-ng/tests.yaml
+++ b/apps/pyload-ng/tests.yaml
@@ -7,9 +7,9 @@ file:
   /usr/local/bin/pyload:
     exists: true
 port:
-  tcp6:8000:
+  tcp:8000:
     listening: true
-  tcp6:9666:
+  tcp:9666:
     listening: true
 http:
   http://localhost:8000:


### PR DESCRIPTION
this adds pyload-ng container.
pyload-ng itself is a pre-release; hope that is not a problem.

~had to use python:3.13-slim because current versions of alpine do not ship `unrar` / `unrar-free` (https://gitlab.alpinelinux.org/alpine/aports/-/issues/17506) and i dont think building it from source is feasible.~
EDIT: image now uses alpine and unrar build by LS.

`entrypoint.sh` copies a default config, when missing, with updated `ip host : "IP address" = 0.0.0.0`.
pyload listens only on localhost per default and i did not find another way.
(not build for ENV support...)

hope this ships with most dependencies to support a variety of plugins.
tested download of rar, zip, tar.gz with auto unpack and it worked.

im not sure how and if multiarch builds work.
is the usage of `VOLUME` in `Dockerfile` correct?

fixes #812
