### PR TITLE
chore: test the smartctl-exporter container

### DIFF
--- a/apps/smartctl-exporter/container_test.go
+++ b/apps/smartctl-exporter/container_test.go
@@ -9,7 +9,7 @@ import (
 
 func Test(t *testing.T) {
 	ctx := context.Background()
-	image := testhelpers.GetTestImage("ghcr.io/home-operations/sabnzbd:rolling")
+	image := testhelpers.GetTestImage("ghcr.io/home-operations/smartctl-exporter:rolling")
 	testhelpers.TestHTTPEndpoint(t, ctx, image, testhelpers.HTTPTestConfig{
 		Port: "9633",
 		Path: "/metrics",


### PR DESCRIPTION
I recently noticed that the tests for smartctl-exporter were for the wrong container image.