### PR TITLE
feat: bump python to 3.14

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -92,7 +92,7 @@
       matchDatasources: ["docker"],
       matchFileNames: ["**/Dockerfile"],
       matchPackageNames: ["/python/"],
-      allowedVersions: "/3\\.13-alpine3\\.22/",
+      allowedVersions: "/3\\.14-alpine3\\.22/",
     },
     {
       description: ["Allowed Java Version for NZBHydra2 Base Image"],

--- a/apps/bazarr/Dockerfile
+++ b/apps/bazarr/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG VENDOR
 ARG VERSION
 

--- a/apps/esphome/Dockerfile
+++ b/apps/esphome/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-slim
+FROM docker.io/library/python:3.14-slim
 ARG VERSION
 
 ENV \

--- a/apps/home-assistant/Dockerfile
+++ b/apps/home-assistant/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH/arm64/aarch64}
-FROM ghcr.io/home-assistant/${ARCH}-base-python:3.13-alpine3.22
+FROM ghcr.io/home-assistant/${ARCH}-base-python:3.14-alpine3.22
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH/arm64/aarch64}
 ARG VERSION

--- a/apps/jbops/Dockerfile
+++ b/apps/jbops/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG VERSION
 
 ENV \

--- a/apps/nzbget/Dockerfile
+++ b/apps/nzbget/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG VERSION
 
 ENV \

--- a/apps/pyload-ng/Dockerfile
+++ b/apps/pyload-ng/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG VERSION
 
 ENV \

--- a/apps/qbittorrent/Dockerfile
+++ b/apps/qbittorrent/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG TARGETARCH
 ARG QBARCH=${TARGETARCH/arm64/aarch64}
 ARG QBARCH=${QBARCH/amd64/x86_64}

--- a/apps/sabnzbd/Dockerfile
+++ b/apps/sabnzbd/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG VERSION
 
 ENV \

--- a/apps/stash/Dockerfile
+++ b/apps/stash/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG TARGETARCH
 ARG STASHARCH=${TARGETARCH/arm64/-arm64v8}
 ARG STASHARCH=${STASHARCH/amd64/}

--- a/apps/tautulli/Dockerfile
+++ b/apps/tautulli/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG VERSION
 
 ENV \

--- a/apps/theme-park/Dockerfile
+++ b/apps/theme-park/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22 AS builder
+FROM docker.io/library/python:3.14-alpine3.22 AS builder
 ARG VERSION
 RUN \
     apk add --no-cache \

--- a/apps/transmission/Dockerfile
+++ b/apps/transmission/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # NOTE: Alpine version is tied to the version in the Renovate annotation in docker-bake.hcl
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG TARGETARCH
 ARG MINIJINJA_ARCH=${TARGETARCH/arm64/aarch64}
 ARG MINIJINJA_ARCH=${MINIJINJA_ARCH/amd64/x86_64}

--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-alpine3.22
+FROM docker.io/library/python:3.14-alpine3.22
 ARG TARGETARCH
 ARG VERSION
 


### PR DESCRIPTION
Bump python to 3.14 in all containers

These apps current fail the build:

- home-assistant
- pyload-ng