### PR TITLE
feat: add glibc to opentofu-runner

### DIFF
--- a/apps/opentofu-runner/Dockerfile
+++ b/apps/opentofu-runner/Dockerfile
@@ -9,5 +9,6 @@ RUN apk add --no-cache curl \
 
 FROM ghcr.io/flux-iac/tf-runner:v0.16.0-rc.7
 USER root
+RUN apk add --no-cache libc6-compat gcompat
 COPY --from=builder --chown=65532:65532 --chmod=755 /tmp/tofu /usr/local/bin/terraform
 USER 65532:65532


### PR DESCRIPTION
This is required for anyone that's using the new 1Password v3.0.0 or newer provider.