### PR TITLE
feat(emby): add Intel VA-API drivers for hardware transcoding

### DIFF
--- a/apps/emby/Dockerfile
+++ b/apps/emby/Dockerfile
@@ -20,6 +20,9 @@ RUN \
         jq \
         nano \
         tzdata \
+        intel-media-va-driver-non-free \
+        libva2 \
+        libva-drm2 \
     && \
     curl -fsSL -o /tmp/emby.deb \
         "https://github.com/MediaBrowser/Emby.Releases/releases/download/${VERSION}/emby-server-deb_${VERSION}_${TARGETARCH}.deb" \


### PR DESCRIPTION
## Summary
- Add Intel media drivers for hardware-accelerated video transcoding on Intel GPUs (Quick Sync)

## Changes
- Added `intel-media-va-driver-non-free` - iHD driver with HEVC/H.264 encode/decode support
- Added `libva2` and `libva-drm2` - VA-API runtime libraries

## Why
The current image lacks VA-API drivers, forcing Emby to use software encoding even when Intel GPU is available. This causes:
- High CPU usage during transcoding
- Inability to transcode 4K HEVC content in real-time
- Poor streaming experience for users

## Tested
- Intel UHD 630 (Coffee Lake) - 4K HEVC → 1080p transcoding
- Kubernetes with Intel GPU resource driver (DRA)

## Impact
- Adds ~50MB to image size
- Enables hardware transcoding on Intel iGPUs (6th gen+)