### PR TITLE
fix(emby): intel things are already packaged by emby

### DIFF
--- a/apps/emby/Dockerfile
+++ b/apps/emby/Dockerfile
@@ -21,13 +21,6 @@ RUN \
         nano \
         tzdata \
     && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get install -y --no-install-recommends --no-install-suggests \
-            intel-media-va-driver-non-free \
-            libva2 \
-            libva-drm2; \
-    fi \
-    && \
     curl -fsSL -o /tmp/emby.deb \
         "https://github.com/MediaBrowser/Emby.Releases/releases/download/${VERSION}/emby-server-deb_${VERSION}_${TARGETARCH}.deb" \
     && \


### PR DESCRIPTION
Removed conditional installation of Intel media driver for amd64 architecture.