### PR TITLE
fix(esphome): pin Python back to 3.13-slim, 3.14 not yet supported

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -104,6 +104,13 @@
       allowedVersions: "/3\\.14-slim/",
     },
     {
+      description: ["Allowed Python Version for ESPHome Base Image"],
+      matchDatasources: ["docker"],
+      matchFileNames: ["apps/esphome/Dockerfile"],
+      matchPackageNames: ["/python/"],
+      allowedVersions: "/3\\.13-slim/",
+    },
+    {
       description: ["Allowed Java Version for NZBHydra2 Base Image"],
       matchDatasources: ["docker"],
       matchFileNames: ["apps/nzbhydra2/Dockerfile"],

--- a/apps/esphome/Dockerfile
+++ b/apps/esphome/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.14-slim
+FROM docker.io/library/python:3.13-slim
 ARG VERSION
 
 ENV \


### PR DESCRIPTION
ESPHome does not yet support Python 3.14. Pin back to 3.13-slim.