### PR TITLE
feat: add tududi container

### DIFF
--- a/apps/tududi/Dockerfile
+++ b/apps/tududi/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/node:22-alpine AS builder
+ARG VERSION
+
+RUN apk add --no-cache \
+        bash \
+        g++ \
+        make \
+        python3 \
+        sqlite-dev
+
+WORKDIR /build
+RUN wget -qO- "https://github.com/chrisvel/tududi/archive/refs/tags/${VERSION}.tar.gz" \
+    | tar xzf - --strip-components=1
+
+# Install all dependencies (devDeps needed for webpack/tsc frontend build)
+RUN npm install
+
+# Build frontend → dist/
+RUN NODE_ENV=production npm run frontend:build
+
+# Prune devDependencies before copying to runtime image
+RUN npm prune --omit=dev
+
+FROM docker.io/library/node:22-alpine
+ARG VERSION
+
+RUN apk add --no-cache \
+        bash \
+        ca-certificates \
+        catatonit \
+        coreutils \
+        nano \
+        sqlite-libs \
+        tzdata
+
+COPY --from=builder /build/backend /app/backend
+COPY --from=builder /build/node_modules /app/node_modules
+COPY --from=builder /build/dist /app/backend/dist
+COPY --from=builder /build/package.json /app/package.json
+
+RUN chown -R root:root /app && chmod -R 755 /app \
+    && mkdir -p /config && chown nobody:nogroup /config
+
+COPY . /
+
+ENV \
+    DB_FILE=/config/tududi.sqlite3 \
+    NODE_ENV=production \
+    PORT=3002 \
+    TUDUDI_UPLOAD_PATH=/config/uploads
+
+USER nobody:nogroup
+WORKDIR /app/backend
+VOLUME ["/config"]
+
+ENTRYPOINT ["/usr/bin/catatonit", "--", "/entrypoint.sh"]

--- a/apps/tududi/container_test.go
+++ b/apps/tududi/container_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/home-operations/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("ghcr.io/home-operations/tududi:rolling")
+	testhelpers.TestHTTPEndpoint(t, ctx, image, testhelpers.HTTPTestConfig{
+		Port:       "3002",
+		Path:       "/api/health",
+		StatusCode: 200,
+	}, &testhelpers.ContainerConfig{
+		Env: map[string]string{
+			"TUDUDI_USER_EMAIL":     "test@example.com",
+			"TUDUDI_USER_PASSWORD":  "testpassword123",
+			"TUDUDI_SESSION_SECRET": "test-session-secret-32chars!!",
+		},
+	})
+}

--- a/apps/tududi/docker-bake.hcl
+++ b/apps/tududi/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "tududi"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-tags depName=chrisvel/tududi
+  default = "v1.1.0-dev.14"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/chrisvel/tududi"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/tududi/docker-bake.hcl
+++ b/apps/tududi/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  // renovate: datasource=github-tags depName=chrisvel/tududi
+  // renovate: datasource=github-releases depName=chrisvel/tududi
   default = "v1.1.0-dev.14"
 }
 

--- a/apps/tududi/entrypoint.sh
+++ b/apps/tududi/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 mkdir -p "${TUDUDI_UPLOAD_PATH:-/config/uploads}"
 

--- a/apps/tududi/entrypoint.sh
+++ b/apps/tududi/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+mkdir -p "${TUDUDI_UPLOAD_PATH:-/config/uploads}"
+
+exec /app/backend/cmd/start.sh "$@"


### PR DESCRIPTION
Adds a rootless, multi-arch container for [tududi](https://github.com/chrisvel/tududi) — a self-hosted task/project manager. 
PR would resolve issue #1354 

  ## Changes
  - Two-stage build: Node.js frontend (webpack) + backend
  - Runs as `nobody:nogroup` (65534:65534) 
  - Runs without the upstream runtime `chown -R`
  - All persistent data via `/config` volume (`DB_FILE`, `TUDUDI_UPLOAD_PATH`)
  - `catatonit` as PID 1
  - Tracks `github-tags` for Renovate 
    - upstream project is releasing `v*-dev.##` via pre-release tags;
    - only these dev releases have OIDC support, not available in v1.0.0 stable

  ## Tests
  - Tested locally and in my cluster with [this image](https://github.com/users/tscibilia/packages/container/package/tududi) before pushing PR