### PR TITLE
fix(kopia): add required flag to bind non-localhost

### DIFF
--- a/apps/kopia/entrypoint.sh
+++ b/apps/kopia/entrypoint.sh
@@ -7,6 +7,7 @@ if [[ ${KOPIA_WEB_ENABLED} == "true" ]]; then
             start \
             --insecure \
             --address "0.0.0.0:${KOPIA_WEB_PORT}" \
+	        --allow-extremely-dangerous-unauthenticated-server-on-the-network \
             "$@"
 else
     exec \


### PR DESCRIPTION
The server will not start anymore if started with ``--insecure`` and ``--without-password`` when the ``--address`` is not on loopback, which is the case for the container.

I think fixing it there makes sense since the predicate does not make sense in containers environments.

source : https://github.com/kopia/kopia/pull/5354