### PR TITLE
ci: compile the Go test harness on every PR

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,6 +26,44 @@ jobs:
           include_only_directories: true
           max_depth: 1
 
+  # Compiles the Go test harness (testhelpers + apps/*/container_test.go) against
+  # go.mod. The per-app integration tests only run when an app is built, so a
+  # go.mod-only change (e.g. a testcontainers-go bump) would otherwise never be
+  # compiled in CI — a breaking dependency change could merge green. The app dirs
+  # are test-only, so `go test -run=^$` compiles every test binary (running none,
+  # no Docker) and `go vet` type-checks them; both catch a broken dependency bump.
+  # Always runs; fast.
+  go-check:
+    name: Go Compile & Vet
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Restore Go Modules
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+
+      - name: Compile tests
+        run: go test -run='^$' ./...
+
+      - name: Vet
+        run: go vet ./...
+
   build:
     if: ${{ needs.prepare.outputs.changed-files != '[]' }}
     name: Build ${{ matrix.app }}
@@ -55,6 +93,7 @@ jobs:
     name: Build Success
     needs:
       - build
+      - go-check
     runs-on: ubuntu-24.04
     permissions: {}
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,13 +26,6 @@ jobs:
           include_only_directories: true
           max_depth: 1
 
-  # Compiles the Go test harness (testhelpers + apps/*/container_test.go) against
-  # go.mod. The per-app integration tests only run when an app is built, so a
-  # go.mod-only change (e.g. a testcontainers-go bump) would otherwise never be
-  # compiled in CI — a breaking dependency change could merge green. The app dirs
-  # are test-only, so `go test -run=^$` compiles every test binary (running none,
-  # no Docker) and `go vet` type-checks them; both catch a broken dependency bump.
-  # Always runs; fast.
   go-check:
     name: Go Compile & Vet
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Problem
Per-app integration tests run via `app-tests` (`go test ./apps/$APP/...`), gated on an **app dir changing** in the `pull-request` build matrix. A `go.mod`-only PR — like the just-merged testcontainers-go `v0.43.0` bump (#1527) — builds no app, so the Go test harness (`testhelpers/` + `apps/*/container_test.go`) is **never compiled in CI**. A breaking dependency change can merge green. (I verified #1527 manually; CI would not have.)

## Fix
Add an always-run `go-check` job to `pull-request.yaml`, wired into the existing **Build Success** aggregator (`status.needs`):

```yaml
- name: Compile tests
  run: go test -run='^$' ./...   # compiles every test binary, runs none, no Docker
- name: Vet
  run: go vet ./...
```

The `apps/*` packages are **test-only** (only `container_test.go`, no non-test `.go`), so a plain `go build ./...` would silently skip them — proven empirically during review: a type error in `apps/sonarr/container_test.go` passes `go build` but fails both `go test -run='^$'` and `go vet`. So the gate uses `go test -run='^$'` (compiles + links each test binary without running it) plus `go vet` (type-checks + analyzers).

Follows repo conventions: `jdx/mise-action` (installs `go 1.26.4`), SHA-pinned actions, `persist-credentials: false`, restore-only Go cache. **zizmor clean.**

## Verified locally
- `go test -run='^$' ./...` → all app test binaries compile, `[no tests to run]`, no containers touched
- `go vet ./...` → pass
- `zizmor .github/workflows/pull-request.yaml` → no findings

## Note on branch protection
`go-check` gates **only** through the existing **Build Success** required check — no branch-protection change needed. Please **don't** promote the new "Go Compile & Vet" check to a directly-required status; keep "Build Success" as the sole required gate (a second direct gate would bypass the `!cancelled()` aggregation logic).