### PR TITLE
refactor(tests): idiomatic naming + tidy in the container test harness

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,13 @@ on:
     branches:
       - main
     paths:
+      # Test-only changes (apps/<app>/container_test.go) must not trigger a
+      # release rebuild+push — that mints a fresh image digest for byte-identical
+      # content (digest churn). The negation is gitignore-style/last-match-wins,
+      # so a push touching a Dockerfile/docker-bake.hcl still matches apps/** and
+      # releases normally; PRs (pull-request.yaml) keep building+running the test.
       - apps/**
+      - "!apps/**/*_test.go"
   workflow_dispatch:
     inputs:
       app:

--- a/apps/actions-runner/container_test.go
+++ b/apps/actions-runner/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/actions-runner:rolling")
-	testhelpers.TestFileExists(t, image, "/usr/local/bin/yq", nil)
+	testhelpers.RequireFileExists(t, image, "/usr/local/bin/yq")
 }

--- a/apps/bazarr/container_test.go
+++ b/apps/bazarr/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/bazarr:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6767"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6767"}, nil)
 }

--- a/apps/busybox/container_test.go
+++ b/apps/busybox/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/busybox:rolling")
-	testhelpers.TestCommandSucceeds(t, image, nil, "/bin/busybox", "--list")
+	testhelpers.RequireCommandSucceeds(t, image, nil, "/bin/busybox", "--list")
 }

--- a/apps/cni-plugins/container_test.go
+++ b/apps/cni-plugins/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/cni-plugins:rolling")
-	testhelpers.TestCommandSucceeds(t, image, nil, "/plugins/macvlan")
+	testhelpers.RequireCommandSucceeds(t, image, nil, "/plugins/macvlan")
 }

--- a/apps/deluge/container_test.go
+++ b/apps/deluge/container_test.go
@@ -8,16 +8,11 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/deluge:rolling")
-	t.Run("HTTP endpoint test", func(t *testing.T) {
-		testhelpers.TestHTTPEndpoint(t, image,
-			testhelpers.HTTPTestConfig{
-				Port: "8112",
-			},
-			&testhelpers.ContainerConfig{
-				Env: map[string]string{
-					"DELUGE_BIN": "deluge-web",
-				},
-			},
-		)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+		Port: "8112",
+	}, &testhelpers.ContainerConfig{
+		Env: map[string]string{
+			"DELUGE_BIN": "deluge-web",
+		},
 	})
 }

--- a/apps/emby/container_test.go
+++ b/apps/emby/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/emby:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8096"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8096"}, nil)
 }

--- a/apps/esphome/container_test.go
+++ b/apps/esphome/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/esphome:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6052"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6052"}, nil)
 }

--- a/apps/home-assistant/container_test.go
+++ b/apps/home-assistant/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/home-assistant:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8123"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8123"}, nil)
 }

--- a/apps/irqbalance/container_test.go
+++ b/apps/irqbalance/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/irqbalance:rolling")
-	testhelpers.TestFileExists(t, image, "/usr/sbin/irqbalance", nil)
+	testhelpers.RequireFileExists(t, image, "/usr/sbin/irqbalance")
 }

--- a/apps/jackett/container_test.go
+++ b/apps/jackett/container_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/jackett:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
 		Port:       "9117",
 		StatusCode: 400,
 	}, nil)

--- a/apps/jbops/container_test.go
+++ b/apps/jbops/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/jbops:rolling")
-	testhelpers.TestFileExists(t, image, "/app/fun/plexapi_haiku.py", nil)
+	testhelpers.RequireFileExists(t, image, "/app/fun/plexapi_haiku.py")
 }

--- a/apps/k8s-sidecar/container_test.go
+++ b/apps/k8s-sidecar/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/k8s-sidecar:rolling")
-	testhelpers.TestCommandSucceeds(t, image, nil, "python", "-u", "-m", "sidecar", "--help")
+	testhelpers.RequireCommandSucceeds(t, image, nil, "python", "-u", "-m", "sidecar", "--help")
 }

--- a/apps/kopia/container_test.go
+++ b/apps/kopia/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/kopia:rolling")
-	testhelpers.TestCommandSucceeds(t, image, nil, "/usr/local/bin/kopia", "--version")
+	testhelpers.RequireCommandSucceeds(t, image, nil, "/usr/local/bin/kopia", "--version")
 }

--- a/apps/lidarr/container_test.go
+++ b/apps/lidarr/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/lidarr:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8686"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8686"}, nil)
 }

--- a/apps/nzbget/container_test.go
+++ b/apps/nzbget/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/nzbget:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6789"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6789"}, nil)
 }

--- a/apps/nzbhydra2/container_test.go
+++ b/apps/nzbhydra2/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/nzbhydra2:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "5076"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "5076"}, nil)
 }

--- a/apps/octoprint/container_test.go
+++ b/apps/octoprint/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/octoprint:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "5000"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "5000"}, nil)
 }

--- a/apps/opentofu-runner/container_test.go
+++ b/apps/opentofu-runner/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/opentofu-runner:rolling")
-	testhelpers.TestFileExists(t, image, "/usr/local/bin/terraform", nil)
+	testhelpers.RequireFileExists(t, image, "/usr/local/bin/terraform")
 }

--- a/apps/plex-next/container_test.go
+++ b/apps/plex-next/container_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/plex-next:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
 		Port: "32400",
 		Path: "/web/index.html",
 	}, nil)

--- a/apps/plex/container_test.go
+++ b/apps/plex/container_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/plex:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
 		Port: "32400",
 		Path: "/web/index.html",
 	}, nil)

--- a/apps/postgres-init/container_test.go
+++ b/apps/postgres-init/container_test.go
@@ -8,8 +8,8 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/postgres-init:rolling")
-	testhelpers.TestFileExists(t, image, "/usr/local/bin/createdb", nil)
-	testhelpers.TestFileExists(t, image, "/usr/local/bin/createuser", nil)
-	testhelpers.TestFileExists(t, image, "/usr/local/bin/psql", nil)
-	testhelpers.TestFileExists(t, image, "/usr/local/bin/pg_isready", nil)
+	testhelpers.RequireFileExists(t, image, "/usr/local/bin/createdb")
+	testhelpers.RequireFileExists(t, image, "/usr/local/bin/createuser")
+	testhelpers.RequireFileExists(t, image, "/usr/local/bin/psql")
+	testhelpers.RequireFileExists(t, image, "/usr/local/bin/pg_isready")
 }

--- a/apps/prowlarr/container_test.go
+++ b/apps/prowlarr/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/prowlarr:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "9696"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "9696"}, nil)
 }

--- a/apps/pyload-ng/container_test.go
+++ b/apps/pyload-ng/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/pyload-ng:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8000"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8000"}, nil)
 }

--- a/apps/qbittorrent-libtorrentv1/container_test.go
+++ b/apps/qbittorrent-libtorrentv1/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/qbittorrent-libtorrentv1:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
 }

--- a/apps/qbittorrent/container_test.go
+++ b/apps/qbittorrent/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/qbittorrent:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
 }

--- a/apps/radarr/container_test.go
+++ b/apps/radarr/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/radarr:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "7878"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "7878"}, nil)
 }

--- a/apps/sabnzbd/container_test.go
+++ b/apps/sabnzbd/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/sabnzbd:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
 }

--- a/apps/smartctl-exporter/container_test.go
+++ b/apps/smartctl-exporter/container_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/smartctl-exporter:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
 		Port: "9633",
 		Path: "/metrics",
 	}, nil)

--- a/apps/sonarr/container_test.go
+++ b/apps/sonarr/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/sonarr:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8989"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8989"}, nil)
 }

--- a/apps/stash/container_test.go
+++ b/apps/stash/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/stash:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "9999"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "9999"}, nil)
 }

--- a/apps/tautulli/container_test.go
+++ b/apps/tautulli/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/tautulli:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8181"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8181"}, nil)
 }

--- a/apps/theme-park/container_test.go
+++ b/apps/theme-park/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/theme-park:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
 }

--- a/apps/tqm/container_test.go
+++ b/apps/tqm/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/tqm:rolling")
-	testhelpers.TestCommandSucceeds(t, image, nil, "/app/bin/tqm", "version")
+	testhelpers.RequireCommandSucceeds(t, image, nil, "/app/bin/tqm", "version")
 }

--- a/apps/transmission/container_test.go
+++ b/apps/transmission/container_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/transmission:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
 		Port:       "9091",
 		StatusCode: 403,
 	}, nil)

--- a/apps/tududi/container_test.go
+++ b/apps/tududi/container_test.go
@@ -8,10 +8,9 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/tududi:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
-		Port:       "3002",
-		Path:       "/api/health",
-		StatusCode: 200,
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{
+		Port: "3002",
+		Path: "/api/health",
 	}, &testhelpers.ContainerConfig{
 		Env: map[string]string{
 			"TUDUDI_USER_EMAIL":     "test@example.com",

--- a/apps/webhook/container_test.go
+++ b/apps/webhook/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/webhook:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "9000"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "9000"}, nil)
 }

--- a/apps/whisparr/container_test.go
+++ b/apps/whisparr/container_test.go
@@ -8,5 +8,5 @@ import (
 
 func Test(t *testing.T) {
 	image := testhelpers.GetTestImage("ghcr.io/home-operations/whisparr:rolling")
-	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6969"}, nil)
+	testhelpers.RequireHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "6969"}, nil)
 }

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -45,6 +45,11 @@ func applyContainerConfig(config *ContainerConfig) []testcontainers.ContainerCus
 }
 
 // tLogConsumer pipes container stdout/stderr to t.Log so failing tests surface what the container said.
+//
+// Safe against the "Log in goroutine after Test completed" panic: the log-pump goroutine is joined
+// before the test finishes. CleanupContainer registers a t.Cleanup that runs Terminate ->
+// stopLogProduction(), which blocks on the pump's done channel synchronously (testcontainers-go
+// v0.43.0). Re-verify this invariant on any major testcontainers upgrade.
 type tLogConsumer struct{ t *testing.T }
 
 func (c *tLogConsumer) Accept(l testcontainers.Log) {
@@ -68,8 +73,8 @@ func runContainer(t *testing.T, ctx context.Context, image string, opts ...testc
 	return c
 }
 
-// assertExitZero waits for container exit (via wait strategy set by caller) and asserts the exit code is zero.
-func assertExitZero(t *testing.T, ctx context.Context, c testcontainers.Container, what string) {
+// requireExitZero waits for container exit (via wait strategy set by caller) and asserts the exit code is zero.
+func requireExitZero(t *testing.T, ctx context.Context, c testcontainers.Container, what string) {
 	t.Helper()
 	state, err := c.State(ctx)
 	require.NoError(t, err)
@@ -84,8 +89,8 @@ type HTTPTestConfig struct {
 	Timeout    time.Duration // optional startup timeout for the HTTP wait strategy (0 = library default)
 }
 
-// TestHTTPEndpoint tests that an HTTP endpoint is accessible and returns the expected status code
-func TestHTTPEndpoint(t *testing.T, image string, httpConfig HTTPTestConfig, containerConfig *ContainerConfig) {
+// RequireHTTPEndpoint tests that an HTTP endpoint is accessible and returns the expected status code
+func RequireHTTPEndpoint(t *testing.T, image string, httpConfig HTTPTestConfig, containerConfig *ContainerConfig) {
 	t.Helper()
 
 	if httpConfig.Path == "" {
@@ -117,18 +122,18 @@ func TestHTTPEndpoint(t *testing.T, image string, httpConfig HTTPTestConfig, con
 	_ = runContainer(t, t.Context(), image, opts...)
 }
 
-// TestFileExists tests that a file exists in the image by inspecting its filesystem directly,
+// RequireFileExists tests that a file exists in the image by inspecting its filesystem directly,
 // without starting the container. Works for images with no shell or executables.
-func TestFileExists(t *testing.T, image string, filePath string, _ *ContainerConfig) {
+func RequireFileExists(t *testing.T, image string, filePath string) {
 	t.Helper()
 
 	ctx := t.Context()
 
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{Image: image, Cmd: []string{"/"}},
-		Started:          false,
-		Logger:           log.TestLogger(t),
-	})
+	ctr, err := testcontainers.Run(ctx, image,
+		testcontainers.WithNoStart(),
+		testcontainers.WithCmd("/"),
+		testcontainers.WithLogger(log.TestLogger(t)),
+	)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -140,8 +145,8 @@ func TestFileExists(t *testing.T, image string, filePath string, _ *ContainerCon
 	require.NoError(t, err, "file %q should exist in image %q", filePath, image)
 }
 
-// TestCommandSucceeds tests that a command runs successfully in the container (exit code 0)
-func TestCommandSucceeds(t *testing.T, image string, config *ContainerConfig, entrypoint string, args ...string) {
+// RequireCommandSucceeds tests that a command runs successfully in the container (exit code 0)
+func RequireCommandSucceeds(t *testing.T, image string, config *ContainerConfig, entrypoint string, args ...string) {
 	t.Helper()
 
 	opts := []testcontainers.ContainerCustomizer{
@@ -157,5 +162,5 @@ func TestCommandSucceeds(t *testing.T, image string, config *ContainerConfig, en
 
 	ctx := t.Context()
 	container := runContainer(t, ctx, image, opts...)
-	assertExitZero(t, ctx, container, fmt.Sprintf("command '%s %v' should succeed", entrypoint, args))
+	requireExitZero(t, ctx, container, fmt.Sprintf("command '%s %v' should succeed", entrypoint, args))
 }


### PR DESCRIPTION
A review-and-tidy pass over the container test harness (`testhelpers/` + the 37 `apps/*/container_test.go`) for DRY / Go-idiomatic / idempotent. Behavior-preserving.

## Changes
**Naming (the main one).** The exported assertion helpers were prefixed `Test*` — reserved by convention for `func TestXxx(*testing.T)` entry points — so parameterized helpers in a non-`_test.go` file read as test cases. Renamed:

| before | after |
|---|---|
| `TestHTTPEndpoint` | `RequireHTTPEndpoint` |
| `TestFileExists` | `RequireFileExists` |
| `TestCommandSucceeds` | `RequireCommandSucceeds` |
| `assertExitZero` (private) | `requireExitZero` (it `FailNow`s via `require`, not `assert`) |

**Tidy:**
- Drop the unused `*ContainerConfig` param from `RequireFileExists` — it inspects the image filesystem without starting a container, so env was always dead; removes the trailing `nil` from its 8 call sites.
- `RequireFileExists` now uses `testcontainers.Run` + `WithNoStart` + `WithCmd`, so the helper speaks one API (drops the last `GenericContainer` usage).
- Comment on `tLogConsumer` explaining why `t.Logf` from the log-pump goroutine is race-free (the pump is joined in `Terminate` before the test completes — testcontainers v0.43.0).
- `deluge`: drop a lone single-child `t.Run` wrapper to match the other 36 files.
- `tududi`: drop a redundant `StatusCode: 200` (already the helper default).

## Deliberately NOT done
Resisted over-churn: no `ctx`-first reorder (`(t, ctx, …)` is the test-helper norm), no `testing.TB` widening, no collapsing the 37 per-app files into a table/generator (they're DAMP specs and CI injects `TEST_IMAGE` per-app), no `msgAndArgs`/`fmt`-drop micro-opt, no silent startup-timeout default (behavior-changing, risks flakiness on slow first pulls).

## Verified
- `go build ./...` + `go vet ./...` clean (also caught by the new `Go Compile & Vet` gate on this PR).
- Live spot-checks against `:rolling` images: **busybox** (command), **postgres-init** (file-exists, no-start path — exercises the `Run`+`WithNoStart` rewrite + dropped `nil`), **deluge** (HTTP + env config + de-`t.Run` shape) — all pass.

---

## Also bundled — stop test-only changes from churning image digests

`release.yaml` builds with `release: true` on push to main, so merging a test-only change rebuilt + re-pushed the app image, minting a fresh digest for byte-identical content. Merging *this* PR (37 `container_test.go` files) would have done it 37×.

Fix — a gitignore-style negation on the release trigger so test-only pushes skip the Release workflow entirely:

```yaml
on:
  push:
    branches: [main]
    paths:
      - apps/**
      - "!apps/**/*_test.go"
```

Last-match-wins: a `Dockerfile`/`docker-bake.hcl` change still matches `apps/**` and releases as before — the negation can only ever match `*_test.go`, so a real release is **never** silently skipped. `pull-request.yaml` is untouched, so PRs still build and run the container tests (`release: false`, no push). Verified against GitHub's path-filter docs; zizmor clean.

Known no-op caveat (unchanged from today): a *mixed* push — one app's `Dockerfile` plus a different app's test-only edit in the same merge — still rebuilds the sibling, because the `prepare` step resolves changed app dirs at `max_depth: 1`. Rare here (Renovate bumps apps one-per-PR) and no worse than current behavior.
