### PR TITLE
chore: align go.mod to go 1.26.4 + group the Go version in renovate

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -52,6 +52,14 @@
   },
   packageRules: [
     {
+      description: [
+        "Group the Go version: the go.mod directive (gomod) and the mise toolchain pin bump together in one PR",
+      ],
+      matchManagers: ["gomod", "mise"],
+      matchDepNames: ["go"],
+      groupName: "golang",
+    },
+    {
       description: ["Release Rules for App Updates"],
       addLabels: ["app/{{parentDir}}"],
       additionalBranchPrefix: "{{parentDir}}-",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/containers
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## What
1. Bump the `go.mod` `go` directive **1.26.2 → 1.26.4** to match the mise toolchain pin (`.mise/config.toml` `go = "1.26.4"`).
2. Add a Renovate `packageRule` grouping the Go version across the `gomod` (go.mod directive) and `mise` managers into one `golang` group.

## Why
The directive had drifted behind mise because Renovate proposed the two Go bumps as **separate** PRs (gomod manager vs mise manager), so only the mise pin moved. The new rule makes future Go bumps land in a single PR, keeping the two in lockstep:

```json5
{
  matchManagers: ["gomod", "mise"],
  matchDepNames: ["go"],
  groupName: "golang",
}
```

## Verified
- `go build ./...` + `go vet ./...` clean under the 1.26.4 directive (also exercised by the `Go Compile & Vet` gate on this PR).
- `renovate-config-validator` (renovate@latest) → *"Config validated successfully"*.

No app dirs touched, so the per-app build matrix is skipped.