### PR TITLE
ci(size-diff): post comment when the artifact extracts flat (single app)

### DIFF
--- a/.github/workflows/size-diff-comment.yaml
+++ b/.github/workflows/size-diff-comment.yaml
@@ -56,12 +56,20 @@ jobs:
               return;
             }
 
-            for (const entry of fs.readdirSync(dir)) {
-              const sub = path.join(dir, entry);
-              if (!fs.statSync(sub).isDirectory()) continue;
+            // A single matching artifact extracts flat into DIR; multiple land
+            // in per-artifact subdirs. Handle both: DIR itself + its subdirs.
+            const candidates = [dir, ...fs.readdirSync(dir)
+              .map(e => path.join(dir, e))
+              .filter(p => fs.statSync(p).isDirectory())];
 
-              const app = fs.readFileSync(path.join(sub, "app"), "utf8").trim();
-              const body = fs.readFileSync(path.join(sub, "body.md"), "utf8");
+            let posted = 0;
+            for (const sub of candidates) {
+              const appPath = path.join(sub, "app");
+              const bodyPath = path.join(sub, "body.md");
+              if (!fs.existsSync(appPath) || !fs.existsSync(bodyPath)) continue;
+
+              const app = fs.readFileSync(appPath, "utf8").trim();
+              const body = fs.readFileSync(bodyPath, "utf8");
               if (!app || !body) continue;
               if (!body.startsWith("## 📦 App Size Analysis")) {
                 core.warning(`Skipping ${app}: unexpected size-diff body.`);
@@ -93,4 +101,7 @@ jobs:
                   body: fullBody,
                 });
               }
+              posted++;
             }
+
+            if (!posted) core.warning("No size-diff payloads found under the artifact dir.");


### PR DESCRIPTION
## Problem

The size-diff comment (added in #1553) never posts on **single-app PRs** — confirmed on [#1554](https://github.com/home-operations/containers/pull/1554) (jackett) and [#1440](https://github.com/home-operations/containers/pull/1440) (esphome). The `Size Diff Comment` `workflow_run` job ran, downloaded the artifact, and exited **green having posted nothing**.

## Root cause

`actions/download-artifact` extracts a **single** matching artifact's files directly into the target `path`, but lands **multiple** artifacts in per-artifact subdirs (`path/<artifact-name>/`). The `size-diff-<app>` artifact contains `app` + `body.md` at its root, so for a single-app PR they end up directly in `DIR`:

```
$DIR/app
$DIR/body.md          # ← not $DIR/size-diff-jackett/...
```

The comment loop only iterated **subdirectories** (`if (!isDirectory()) continue`), so both files were skipped, nothing was posted, and — since no code path errored — the job stayed green and logged nothing. Multi-app PRs happened to work (download-artifact uses subdirs there to avoid `app`/`body.md` name collisions).

Verified the layout directly: the artifact's internal structure is `app` + `body.md` at the root, and the download step logs `Starting download of artifact to: …/size-diff` (no per-artifact subdir for the single match).

## Fix

Iterate `DIR` **itself plus its immediate subdirectories**, so both extraction layouts work, and `core.warning` if nothing was posted so a silent miss can't recur. Tested locally against both layouts:

| layout | old loop | new loop |
| :-- | :-- | :-- |
| flat (single artifact) | `[]` ❌ | `[jackett]` ✅ |
| subdirs (multiple artifacts) | `[jackett, sonarr]` | `[jackett, sonarr]` ✅ |

## Validation note

This is the `workflow_run` path that can only run from the **default branch**, so it's first exercised after this merges. Once merged, re-running #1440's `Pull Request` workflow (or the next release PR) will confirm the comment posts end-to-end.
