### PR TITLE
ci(retry-release): replace unmaintained find-pull-request-action with github-script

### DIFF
--- a/.github/workflows/retry-release.yaml
+++ b/.github/workflows/retry-release.yaml
@@ -82,12 +82,21 @@ jobs:
 
       - if: ${{ steps.app-options.outputs.version != steps.registry.outputs.version }}
         name: Find Pull Request
-        uses: juliangruber/find-pull-request-action@92b38d91ef26fd0f47374257f50e78432359a45f # v1.11.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: find-pull-request
+        env:
+          APP: ${{ matrix.app }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
-          labels: app/${{ matrix.app }}
-          state: open
+          script: |
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const pr = prs.find(p => p.labels.some(l => l.name === `app/${process.env.APP}`));
+            core.setOutput("number", pr ? pr.number : "");
 
       - if: ${{ steps.find-pull-request.outputs.number != '' }}
         name: Retry Release


### PR DESCRIPTION
## Why

A full-repo audit (tooling + workflow-logic) found the repo CI is already clean — **one** thing stood out: `retry-release.yaml` is the only workflow still using a third-party action that isn't otherwise trusted/pinned-by-convention here — `juliangruber/find-pull-request-action` (last released 2023, effectively unmaintained). It's used to find the open `app/<app>`-labeled PR before the drift-watchdog re-dispatches `release.yaml`.

## Change

Swap it for `actions/github-script@v9` — the **exact pinned SHA already used 7× in this repo** (so Renovate manages it and there's no version drift):

```js
const prs = await github.paginate(github.rest.pulls.list, {
  owner: context.repo.owner, repo: context.repo.repo, state: "open", per_page: 100,
});
const pr = prs.find(p => p.labels.some(l => l.name === `app/${process.env.APP}`));
core.setOutput("number", pr ? pr.number : "");
```

- Uses `pulls.list` (paginated), which matches the app-token's existing `pull-requests: read` grant — `issues.listForRepo` would have needed `issues: read`, which isn't granted.
- The downstream gate (`if: steps.find-pull-request.outputs.number != ''`) is **unchanged**; the number is only used as a presence test.

## Safety

- Removes the repo's lone unmaintained CI action; shrinks supply-chain surface; nothing else changes.
- This is a **1:30 AM cron drift-watchdog** that only *triggers* the (untouched) `release.yaml`. Worst case from a bad query is a missed or spurious retry — and `release.yaml` is unedited. Easy to exercise via `workflow_dispatch`.
- zizmor + actionlint clean (the two actionlint infos on the `GITHUB_STEP_SUMMARY` echo are pre-existing and unrelated — `SC2016` there is a false positive since GHA expands `${{ }}` before the shell).
