### PR TITLE
ci: stop cancelling in-progress main runs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   prepare:


### PR DESCRIPTION
Consolidates the CI concurrency change from home-operations/miroir#265:

- `concurrency.cancel-in-progress` now only cancels **pull_request** runs, so pushes to `main` are no longer interrupted mid-run.
