### PR TITLE
feat: add thelounge container

### DIFF
--- a/apps/thelounge/Dockerfile
+++ b/apps/thelounge/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/node:24-alpine AS builder
+ARG VERSION
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+RUN npm install --omit=dev "thelounge@${VERSION#*v}"
+
+FROM docker.io/library/node:24-alpine
+ARG VERSION
+
+RUN apk add --no-cache \
+        bash \
+        ca-certificates \
+        catatonit \
+        coreutils \
+        nano \
+        tzdata
+
+COPY --from=builder /app /app
+
+RUN chown -R root:root /app && chmod -R 755 /app \
+    && mkdir -p /config && chown nobody:nogroup /config
+
+COPY . /
+
+ENV \
+    THELOUNGE_HOME=/config/thelounge \
+    THELOUNGE_MESSAGE_STORAGE="[sqlite]" \
+    THELOUNGE_PORT=9000 \
+    THELOUNGE_STORAGE_POLICY_DELETION_POLICY=everything \
+    THELOUNGE_STORAGE_POLICY_ENABLED=true \
+    THELOUNGE_STORAGE_POLICY_MAX_AGE_DAYS=30
+
+USER nobody:nogroup
+WORKDIR /app
+VOLUME ["/config"]
+
+ENTRYPOINT ["/usr/bin/catatonit", "--", "/entrypoint.sh"]

--- a/apps/thelounge/container_test.go
+++ b/apps/thelounge/container_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	helpers "github.com/home-operations/containers/tests"
+)
+
+func Test(t *testing.T) {
+	image := helpers.GetTestImage("ghcr.io/home-operations/thelounge:rolling")
+	helpers.RequireHTTPEndpoint(t, image, helpers.HTTPTestConfig{
+		Port: "9000",
+	}, &helpers.ContainerConfig{
+		Env: map[string]string{
+			"THELOUNGE_USER":     "test",
+			"THELOUNGE_PASSWORD": "testpassword123",
+		},
+	})
+}

--- a/apps/thelounge/docker-bake.hcl
+++ b/apps/thelounge/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "thelounge"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=thelounge/thelounge
+  default = "v4.5.2"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/thelounge/thelounge"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/thelounge/entrypoint.sh
+++ b/apps/thelounge/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+THELOUNGE_HOME="${THELOUNGE_HOME:-/config/thelounge}"
+
+mkdir -p "${THELOUNGE_HOME}/users"
+
+if [[ -n "${THELOUNGE_USER}" && -n "${THELOUNGE_PASSWORD}" && ! -f "${THELOUNGE_HOME}/users/${THELOUNGE_USER}.json" ]]; then
+    node /app/node_modules/thelounge/index.js add "${THELOUNGE_USER}" --password "${THELOUNGE_PASSWORD}"
+fi
+
+# The Lounge keeps the first occurrence of a --config key, so "$@" goes
+# first to let container args override these env-provided defaults
+exec \
+    node /app/node_modules/thelounge/index.js \
+        start \
+        "$@" \
+        --config port="${THELOUNGE_PORT:-9000}" \
+        --config messageStorage="${THELOUNGE_MESSAGE_STORAGE:-[sqlite]}" \
+        --config storagePolicy.enabled="${THELOUNGE_STORAGE_POLICY_ENABLED:-true}" \
+        --config storagePolicy.maxAgeDays="${THELOUNGE_STORAGE_POLICY_MAX_AGE_DAYS:-30}" \
+        --config storagePolicy.deletionPolicy="${THELOUNGE_STORAGE_POLICY_DELETION_POLICY:-everything}"


### PR DESCRIPTION
Adds a container build for [The Lounge](https://github.com/thelounge/thelounge) v4.5.2, a self-hosted web IRC client.

- Two-stage build on `node:24-alpine`: the builder installs the prebuilt `thelounge` npm package (with `git` available for its GitHub-pinned `irc-framework` dependency), and the runtime stage copies `/app` over, following the same layout as the other node-based apps (e.g. tududi).
- `THELOUNGE_HOME=/config/thelounge` (created by the entrypoint on first run), runs as `nobody:nogroup`.
- Env-configurable defaults:
  - `THELOUNGE_PORT` (`9000`)
  - `THELOUNGE_MESSAGE_STORAGE` (`[sqlite]`, dropping upstream's unbounded plain-text logs; set to `[sqlite, text]` to restore them)
  - `THELOUNGE_STORAGE_POLICY_ENABLED` (`true`), `THELOUNGE_STORAGE_POLICY_MAX_AGE_DAYS` (`30`), `THELOUNGE_STORAGE_POLICY_DELETION_POLICY` (`everything`) — sqlite message retention; by default messages older than 30 days are pruned (set `THELOUNGE_STORAGE_POLICY_ENABLED=false` for upstream's keep-forever behavior)
- Optional first-run user bootstrap: setting `THELOUNGE_USER` and `THELOUNGE_PASSWORD` creates the user before the server starts (skipped if the user already exists).
- Any other config can be overridden via container args, e.g. `["-c", "reverseProxy=true"]`; args are forwarded ahead of the env defaults so they take precedence (The Lounge keeps the first occurrence of a `--config` key).
- Container test boots with the bootstrap env and verifies the web UI responds on `:9000`; verified locally (builds and the test passes against the local image).

Refs: https://github.com/thelounge/thelounge-docker