### PR TITLE
fix(esphome): replace removed dashboard with esphome-device-builder

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -102,13 +102,6 @@
       allowedVersions: "/3\\.14-slim/",
     },
     {
-      description: ["Allowed Python Version for ESPHome Base Image"],
-      matchDatasources: ["docker"],
-      matchFileNames: ["apps/esphome/Dockerfile"],
-      matchPackageNames: ["/python/"],
-      allowedVersions: "/3\\.13-slim/",
-    },
-    {
       description: ["Allowed Java Version for NZBHydra2 Base Image"],
       matchDatasources: ["docker"],
       matchFileNames: ["apps/nzbhydra2/Dockerfile"],

--- a/apps/esphome/Dockerfile
+++ b/apps/esphome/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/python:3.13-slim
+FROM docker.io/library/python:3.14-slim
 ARG VERSION
+# renovate: datasource=pypi depName=esphome-device-builder
+ARG DEVICE_BUILDER_VERSION=1.6.3
 
 ENV \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
@@ -41,6 +43,8 @@ RUN \
     && uv pip install \
         setuptools \
         "esphome[displays]==${VERSION}" \
+        "esphome-device-builder==${DEVICE_BUILDER_VERSION}" \
+    && mkdir -p /cache /config && chown nobody:nogroup /cache /config \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && apt-get autoremove -y \
     && apt-get clean \
@@ -51,6 +55,7 @@ COPY . /
 USER nobody:nogroup
 
 WORKDIR /config
+VOLUME ["/cache", "/config"]
 
 ENTRYPOINT ["/usr/bin/catatonit", "--", "/entrypoint.sh"]
-CMD ["dashboard", "/config"]
+CMD ["/config"]

--- a/apps/esphome/docker-bake.hcl
+++ b/apps/esphome/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "APP" {
 
 variable "VERSION" {
   // renovate: datasource=pypi depName=esphome
-  default = "2026.6.5"
+  default = "2026.7.0"
 }
 
 variable "SOURCE" {

--- a/apps/esphome/entrypoint.sh
+++ b/apps/esphome/entrypoint.sh
@@ -12,5 +12,13 @@ mkdir -p "${ESPHOME_DATA_DIR}"
 # Prune PIO files
 pio system prune --force
 
-# Launch ESPHome
-exec /usr/local/bin/esphome "$@"
+# Set ESPHOME_CLI=true to run the esphome CLI (compile, run, logs, ...)
+# instead of the Device Builder dashboard
+if [[ "${ESPHOME_CLI:-false}" == "true" ]]; then
+    exec /usr/local/bin/esphome "$@"
+fi
+
+# The dashboard was removed from esphome core in 2026.7.0 in favor of Device Builder.
+# An empty --host binds IPv4 and IPv6 separately, like the old dashboard did;
+# Device Builder defaults to 0.0.0.0 and an explicit "::" is IPv6-only
+exec /usr/local/bin/esphome-device-builder --host "" "$@"


### PR DESCRIPTION
ESPHome 2026.7.0 removed the built-in dashboard from core, which is why #1609 fails: the old `CMD ["dashboard", "/config"]` now exits with "The built-in dashboard has been removed from ESPHome. Install and run ESPHome Device Builder instead", so the container test's HTTP wait on `:6052` never succeeds.

This migrates the image to the replacement:

- Bump `esphome` to 2026.7.0 and install [`esphome-device-builder`](https://github.com/esphome/device-builder) (pinned to 1.6.3 with its own renovate pypi annotation, since it versions independently of esphome core).
- The container now always runs the Device Builder dashboard, with container args forwarded to it (`CMD ["/config"]`), so dashboard flags like `--trusted-domains` are plain args. Setting `ESPHOME_CLI=true` switches the entrypoint to the `esphome` CLI instead, for one-shot jobs (`compile`, `run`, `logs`, ...). The legacy `dashboard` command is gone.
- Bind the dashboard dual-stack via `--host ""` (aiohttp binds separate IPv4 and IPv6 listeners) to match the old tornado dashboard. Device Builder's default is IPv4-only `0.0.0.0`, and an explicit `::` ends up IPv6-only because asyncio sets `IPV6_V6ONLY` — either single-stack bind breaks published-port access on hosts that map the other family (this is what made the first CI run time out despite the server being ready). A user-supplied `--host` still overrides, since argparse keeps the last occurrence.
- Declare `VOLUME ["/cache", "/config"]` and create both dirs owned by `nobody:nogroup`. The ownership fix is required, not just cosmetic: Device Builder (unlike the old dashboard) hard-fails at startup writing `secrets.yaml` into a non-writable config dir, and anonymous volumes copy ownership from the image dirs — with root-owned dirs the container is broken whenever nothing is mounted. This also removes the long-standing `PermissionError: '/cache'` startup noise.
- Bump the base image to `python:3.14-slim` and drop the renovate rule pinning esphome to 3.13 (esphome supports 3.14 since [esphome@db6aea8](https://github.com/esphome/esphome/commit/db6aea8969ba5fe6f7e6202e1d8f68f27a13cad3)); supersedes #1440.

Verified locally (image builds on 3.14, container test passes, anonymous volumes come up owned by `nobody`, `ESPHOME_CLI=true ... version` runs the CLI) and CI is green on both amd64 and arm64.

Closes #1609. Closes #1440.