### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ By default the majority of our containers run as a non-root user (`65534:65534`)
 
 ```yaml
 services:
-    home-assistant:
-        image: ghcr.io/home-operations/home-assistant:2025.5.1@sha256:516ae5c85089b3f2960cf2a21dc3c105356969499964fabf0b0358e5f3a7e0a2
-        container_name: home-assistant
-        user: 1000:1000 # The data volume permissions must match this user:group
-        read_only: true # May require mounting in additional dirs as tmpfs
-        tmpfs:
-            - /tmp:rw
-        # ...
+  home-assistant:
+    image: ghcr.io/home-operations/home-assistant:2025.5.1@sha256:516ae5c85089b3f2960cf2a21dc3c105356969499964fabf0b0358e5f3a7e0a2
+    container_name: home-assistant
+    user: 1000:1000 # The data volume permissions must match this user:group
+    read_only: true # May require mounting in additional dirs as tmpfs
+    tmpfs:
+      - /tmp:rw
+    # ...
 ```
 
 #### Kubernetes
@@ -61,35 +61,35 @@ services:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: home-assistant
+  name: home-assistant
 # ...
 spec:
+  # ...
+  template:
     # ...
-    template:
-        # ...
-        spec:
-            containers:
-                - name: home-assistant
-                  image: ghcr.io/home-operations/home-assistant:2025.5.1@sha256:516ae5c85089b3f2960cf2a21dc3c105356969499964fabf0b0358e5f3a7e0a2
-                  securityContext: # May require mounting in additional dirs as emptyDir
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                          drop:
-                              - ALL
-                      readOnlyRootFilesystem: true
-                  volumeMounts:
-                      - name: tmp
-                        mountPath: /tmp
-            # ...
-            securityContext:
-                runAsUser: 1000
-                runAsGroup: 1000
-                fsGroup: 1000 # (Requires CSI support)
-                fsGroupChangePolicy: OnRootMismatch # (Requires CSI support)
-            volumes:
-                - name: tmp
-                  emptyDir: {}
-            # ...
+    spec:
+      containers:
+        - name: home-assistant
+          image: ghcr.io/home-operations/home-assistant:2025.5.1@sha256:516ae5c85089b3f2960cf2a21dc3c105356969499964fabf0b0358e5f3a7e0a2
+          securityContext: # May require mounting in additional dirs as emptyDir
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      # ...
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000 # (Requires CSI support)
+        fsGroupChangePolicy: OnRootMismatch # (Requires CSI support)
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      # ...
 # ...
 ```
 
@@ -99,8 +99,8 @@ Some applications only allow certain configurations via command-line arguments r
 
 ```yaml
 args:
-    - --port
-    - "8080"
+  - --port
+  - "8080"
 ```
 
 ### Configuration Volume
@@ -141,10 +141,10 @@ We encourage the use of official upstream container images whenever possible. Ho
 
 - The upstream application is **actively maintained**.
 - **And** one of the following applies:
-    - no official image exists.
-    - the official image does not support **multi-architecture builds**.
-    - the official image uses tools like **s6-overlay**, **gosu**, or other unconventional initialization mechanisms.
-    - does not tag releases.
+  - no official image exists.
+  - the official image does not support **multi-architecture builds**.
+  - the official image uses tools like **s6-overlay**, **gosu**, or other unconventional initialization mechanisms.
+  - does not tag releases.
 
 ## Deprecations
 


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

`oxfmt` applies a markdown file's `tabWidth` to embedded code blocks. With `[*.md] indent_size = 4`, yaml examples inside the docs get rewritten to 4-space indentation while the yaml files they document stay at 2 under `[*] indent_size = 2`. Anyone copying from the README gets the wrong style. This sets `[*.md] indent_size = 2`.

The reformat is cosmetic: verified across the org that rendered markdown structure is unchanged (no new indented-code-blocks, identical list nesting) and that embedded yaml parses to identical values, block scalars included. Reindented here with the repo's pinned oxfmt.