### PR TITLE
ci(renovate): auto-merge esphome-device-builder updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -69,6 +69,16 @@
       ignoreTests: false,
     },
     {
+      // esphome-device-builder is a first-party companion to the esphome app
+      // (lives in apps/esphome/Dockerfile, not the bake file), so the bake-only
+      // rule above skips it. Auto-merge it like the app itself; CI still gates.
+      description: ["Auto-merge esphome-device-builder Updates"],
+      matchDepNames: ["esphome-device-builder"],
+      automerge: true,
+      automergeType: "pr",
+      ignoreTests: false,
+    },
+    {
       description: ["Allowed Ubuntu Version for Base Images"],
       matchDatasources: ["docker"],
       matchPackageNames: ["/ubuntu/"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -69,9 +69,6 @@
       ignoreTests: false,
     },
     {
-      // esphome-device-builder is a first-party companion to the esphome app
-      // (lives in apps/esphome/Dockerfile, not the bake file), so the bake-only
-      // rule above skips it. Auto-merge it like the app itself; CI still gates.
       description: ["Auto-merge esphome-device-builder Updates"],
       matchDepNames: ["esphome-device-builder"],
       automerge: true,


### PR DESCRIPTION
## What

Adds a targeted Renovate rule so `esphome-device-builder` updates auto-merge, closing the gap that left [#1643](https://github.com/home-operations/containers/pull/1643) (and every future device-builder bump) reporting **"Automerge: Disabled by config."**

## Why it wasn't auto-merging

The existing **"Auto-merge App Updates"** rule matches only `**/docker-bake.hcl`:

```json5
{
  description: ["Auto-merge App Updates"],
  matchFileNames: ["**/docker-bake.hcl"],
  automerge: true,
  automergeType: "pr",
  ignoreTests: false,
},
```

Each app's `docker-bake.hcl` carries its **primary** `VERSION` (for esphome, `esphome` itself), while the `Dockerfile` carries companion/base deps. `esphome-device-builder` is a first-party esphome companion pinned in `apps/esphome/Dockerfile`:

```dockerfile
# renovate: datasource=pypi depName=esphome-device-builder
ARG DEVICE_BUILDER_VERSION=1.6.8
```

So it sits outside the bake-only auto-merge rule and its PRs require a manual merge.

## The rule

```json5
{
  description: ["Auto-merge esphome-device-builder Updates"],
  matchDepNames: ["esphome-device-builder"],
  automerge: true,
  automergeType: "pr",
  ignoreTests: false,
},
```

- **Scoped by `depName`**, deliberately *not* by broadening the rule to `**/Dockerfile` — that would also auto-merge base-image bumps (`python`, `alpine`) which are review-gated by the `allowedVersions` rules below. Only the esphome companion auto-merges.
- Mirrors the app-update idiom: `automergeType: "pr"` + `ignoreTests: false`, so the image build/test CI must pass before the merge happens.
- No `matchUpdateTypes` restriction, matching the bake app-update rule (which auto-merges the main esphome version on any bump). If you'd rather hold majors for review, add `matchUpdateTypes: ["minor", "patch", "digest"]`.

## Verification

`renovate-config-validator --strict` passes:

```
INFO: Validating .renovaterc.json5
INFO: Config validated successfully
```