### PR TITLE
chore(renovate): drop the redundant automergeType override

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -65,7 +65,6 @@
       description: ["Auto-merge App Updates"],
       matchFileNames: ["**/docker-bake.hcl"],
       automerge: true,
-      automergeType: "pr",
       ignoreTests: false,
     },
     {


### PR DESCRIPTION
## Overview

Drops `automergeType: "pr"`, which now only restates the inherited default.

## Additional information

home-operations/renovate-config#39 swapped `:automergeBranch` for `:automergePr`
in the shared preset, so `automergeType: "pr"` is the org-wide default and this
line is redundant.

It was load-bearing until that merged: this repo sets `automerge: true`, so
without the explicit override it would have inherited branch automerge and pushed
those merges straight to `main` with no pull request. That ordering is why this
change waited for #39 rather than going in alongside it.

`ignoreTests: false` is left alone — it predates this work and is not made
redundant by it.

Validated with `renovate-config-validator --strict`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.
