### PR TITLE
chore(renovate): drop the redundant automergeType override

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -71,7 +71,6 @@
       description: ["Auto-merge esphome-device-builder Updates"],
       matchDepNames: ["esphome-device-builder"],
       automerge: true,
-      automergeType: "pr",
       ignoreTests: false,
     },
     {


### PR DESCRIPTION
## Overview

The shared preset extends `:automergePr` (home-operations/renovate-config#39), so
`automergeType: "pr"` on the `esphome-device-builder` rule only restates the
inherited default.

Same cleanup as `1ee460a`, which landed just before this rule was added and so
missed it.

`ignoreTests: false` is left alone — it predates this and is not made redundant
by it.

Validated with `renovate-config-validator --strict`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.