### PR TITLE
feat(kata-guest-kernel): add nested-virtualization guest kernel for Kata

### DIFF
--- a/apps/kata-guest-kernel/Dockerfile
+++ b/apps/kata-guest-kernel/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1
+
+ARG VERSION
+
+FROM docker.io/library/debian:trixie-slim AS build
+ARG VERSION
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+RUN \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bc bison build-essential ca-certificates curl flex libelf-dev \
+        libssl-dev python3 xz-utils zstd \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+WORKDIR /build
+
+# Kata's guest kernel .config and the upstream default QEMU runtime config
+RUN \
+    curl -fsSL "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-amd64.tar.zst" \
+        | zstd -d \
+        | tar -x ./opt/kata/share/kata-containers ./opt/kata/share/defaults/kata-containers
+
+# Kata ships several kernel configs (-debug, -nvidia-gpu, -dragonball-experimental);
+# the regex selects only the plain one, which is what the extension's
+# vmlinux.container is built from. The kernel version comes from that file name,
+# so it cannot drift from what the guest image and agent expect.
+RUN \
+    cfg="$(find opt/kata/share/kata-containers -maxdepth 1 -regextype posix-extended -regex '.*/config-[0-9.]+-[0-9]+' -print -quit)" \
+    && [[ -n "${cfg}" ]] \
+    && kver="${cfg##*/}" \
+    && kver="${kver#config-}" \
+    && kver="${kver%-*}" \
+    && [[ "${kver}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    && echo "kata ${VERSION} guest kernel ${kver} from ${cfg}" \
+    && cp "${cfg}" /config-kata \
+    && mkdir -p /build/linux \
+    && curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v${kver%%.*}.x/linux-${kver}.tar.xz" \
+        | tar -xJ --strip-components=1 -C /build/linux
+
+WORKDIR /build/linux
+
+# Kata's own config plus KVM host support; the asserts fail the build rather
+# than shipping a kernel that silently cannot nest
+RUN \
+    cp /config-kata .config \
+    && ./scripts/config --enable CONFIG_VIRTUALIZATION \
+                        --enable CONFIG_KVM \
+                        --enable CONFIG_KVM_INTEL \
+                        --enable CONFIG_KVM_AMD \
+    && make olddefconfig \
+    && grep -q '^CONFIG_KVM=y' .config \
+    && grep -q '^CONFIG_KVM_INTEL=y' .config \
+    && make -j"$(nproc)" vmlinux \
+    && cp vmlinux /vmlinux-nested
+
+WORKDIR /build
+
+# The two rewrites the siderolabs/kata-containers extension applies to the
+# upstream default, plus the kernel path. The result is byte-identical to the
+# extension's configuration-qemu.toml except for that one line.
+RUN \
+    sed -e 's|/opt/kata|/usr/local|g' \
+        -e 's|^firmware_volume = .*|firmware_volume = ""|' \
+        -e 's|^kernel = .*|kernel = "/var/lib/kata-nested/vmlinux-nested"|' \
+        opt/kata/share/defaults/kata-containers/configuration-qemu.toml \
+        > /configuration-qemu.toml \
+    && grep -q '^kernel = "/var/lib/kata-nested/vmlinux-nested"$' /configuration-qemu.toml \
+    && grep -q '^path = "/usr/local/bin/qemu-system-x86_64"$' /configuration-qemu.toml \
+    && ! grep -q '/opt/kata' /configuration-qemu.toml
+
+FROM docker.io/library/alpine:3.24
+
+ENV KATA_GUEST_KERNEL_DIR=/host/var/lib/kata-nested
+
+RUN \
+    apk add --no-cache \
+        rsync \
+    && rm -rf /tmp/*
+
+COPY --from=build /vmlinux-nested /artifacts/vmlinux-nested
+COPY --from=build /configuration-qemu.toml /artifacts/configuration-qemu.toml
+
+# rsync writes to a temporary file and renames, so a booted VM keeps its open
+# inode, and unchanged artifacts are not recopied on every pod start
+# hadolint ignore=DL3025
+CMD rsync -a /artifacts/ $KATA_GUEST_KERNEL_DIR/

--- a/apps/kata-guest-kernel/container_test.go
+++ b/apps/kata-guest-kernel/container_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	helpers "github.com/home-operations/containers/tests"
+)
+
+func Test(t *testing.T) {
+	image := helpers.GetTestImage("ghcr.io/home-operations/kata-guest-kernel:rolling")
+	helpers.RequireFileExists(t, image, "/artifacts/vmlinux-nested")
+	helpers.RequireFileExists(t, image, "/artifacts/configuration-qemu.toml")
+}

--- a/apps/kata-guest-kernel/docker-bake.hcl
+++ b/apps/kata-guest-kernel/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "kata-guest-kernel"
+}
+
+// Must track the Kata release shipped by the siderolabs/kata-containers Talos
+// extension (KATA_CONTAINERS_VERSION in its vars.yaml), NOT the latest Kata
+// release. The extension supplies the shim, QEMU and guest image that consume
+// this kernel and its generated configuration-qemu.toml, so a skew pairs them
+// with a mismatched guest and a config the on-node shim did not ship with.
+//
+// Deliberately not renovate-annotated: Kata 4.0.0 is released while the
+// extension is still on 3.32.0, and an automatic bump would silently break
+// nested KVM on every node.
+variable "VERSION" {
+  default = "3.32.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/kata-containers/kata-containers"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+// KVM host support is x86-only here: nested KVM on arm64 additionally needs the
+// VMM to emulate EL2 (`-M virt,virtualization=on`), which Kata does not configure.
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}


### PR DESCRIPTION
## What

A Kata guest kernel with KVM host support compiled in, so workloads running under
a Kata VM can use **nested** virtualization. Published as
`ghcr.io/home-operations/kata-guest-kernel`, x86-64 only.

The image installs itself, following the same pattern as `cni-plugins` in this
repo: `CMD rsync -a /artifacts/ $KATA_GUEST_KERNEL_DIR/`, with the destination
defaulting to `/host/var/lib/kata-nested`. Consumers run it as an init container
with a hostPath mounted there. rsync renames into place, so a booted VM keeps its
open inode, and unchanged artifacts are not recopied on restart.

| path | purpose |
|---|---|
| `/artifacts/vmlinux-nested` | the guest kernel |
| `/artifacts/configuration-qemu.toml` | matching Kata runtime config pointing at it |

## Why

The `siderolabs/kata-containers` extension now ships QEMU with `-cpu host`
([siderolabs/extensions#1157](https://github.com/siderolabs/extensions/pull/1157)),
which exposes `vmx` to the guest CPU. That turns out to be necessary but not
sufficient: Kata's stock guest kernel is built **without** `CONFIG_KVM`, and the
guest has no module loading, so `/dev/kvm` can never appear. Observed on a Talos
v1.14 node running the extension:

```
$ kubectl exec <pod on kata-qemu> -- sh -c 'grep -o vmx /proc/cpuinfo; ls /dev/kvm; dmesg | grep -ci kvm_intel'
vmx
ls: /dev/kvm: No such file or directory
0
```

The use case is a GitHub Actions runner whose e2e jobs boot QEMU VMs
(`talosctl cluster create --provisioner qemu`). Without nested KVM those jobs
either fall back to TCG or fail outright, which forces the runner to stay
privileged on the host kernel instead of being confined to a Kata VM.

## How

The kernel is built from **Kata's own shipped `.config`** — extracted from the
same `kata-static` release tarball the extension repackages — with only four
options flipped on:

```
CONFIG_VIRTUALIZATION, CONFIG_KVM, CONFIG_KVM_INTEL, CONFIG_KVM_AMD
```

so the result is the stock guest kernel plus one subsystem, not a bespoke build.
The build asserts `CONFIG_KVM=y` and `CONFIG_KVM_INTEL=y` survive `olddefconfig`
rather than trusting it.

The kernel version is **derived** from the config file name rather than pinned
separately, so it cannot drift from what the guest image and agent expect —
`VERSION` (the Kata release) is the only input. Note the tarball ships four
configs (`-debug`, `-nvidia-gpu`, `-dragonball-experimental`, plain), so the
regex selects only the plain one, which is what `vmlinux.container` is built from.

`configuration-qemu.toml` is generated from the upstream default with the same two
rewrites the Talos extension applies (`/opt/kata` → `/usr/local`, blanked
`firmware_volume`) plus the kernel path, and the build asserts all three landed.
Verified against a live node — the generated file and the extension's differ by
exactly one line:

```
16c16
< kernel = "/usr/local/share/kata-containers/vmlinux.container"
---
> kernel = "/var/lib/kata-nested/vmlinux-nested"
```

## amd64 only

`image-all` declares `linux/amd64` alone. `CONFIG_KVM_INTEL`/`CONFIG_KVM_AMD` are
x86 symbols, and nested KVM on arm64 additionally requires the VMM to emulate EL2
(`-M virt,virtualization=on`), which Kata does not configure — an arm64 build
would be dead weight.

## Verified

Built and run on a 3-node Talos v1.14.0-beta.0 cluster (Intel Core Ultra 5 125H),
consumed as a Kubernetes image volume and staged to `/var/lib/kata-nested/` by a
DaemonSet, with a `CRICustomizationConfig` registering a `kata-qemu-nested`
containerd handler:

| check | result |
|---|---|
| KVM registered in guest | `/proc/misc` → `232 kvm`; `kvm_intel` loaded; `nested = Y` |
| Device functional | `KVM_GET_API_VERSION` → `12`, on all three nodes |
| QEMU agrees | monitor `info kvm` → `kvm support: enabled`; `-cpu host` accepted |
| L2 VM boots | Alpine 6.12.96 kernel booted under nested KVM, reported `Hypervisor detected: KVM`, reached VFS mount at 0.43s |

Consumer side: onedr0p/home-ops#11387.

### Note for consumers

Kata gives containers a minimal `/dev`, so `/dev/kvm` is not present by default.
Get it with a `hostPath` volume of `type: CharDevice` — no `mknod`, and no
`privileged` required:

```yaml
volumes:
  - name: kvm
    hostPath: { path: /dev/kvm, type: CharDevice }
volumeMounts:
  - { name: kvm, mountPath: /dev/kvm }
```

This looks like host passthrough and is not: Kata skips host devices when sharing
mounts, so the agent canonicalises and bind-mounts the path *inside the guest*, and
the container gets the guest kernel's KVM. Verified by falsification — the same
volume on the stock `kata-qemu` RuntimeClass makes the container fail to start
(`failed to create shim task: No such file or directory`), because that guest
kernel has no KVM. If the host device were being passed through, it would have
worked there too.

## Upstream

This should eventually go away. The natural home is a `nested-virt` build-type
fragment in kata-containers itself
(`tools/packaging/kernel/configs/fragments/build-type/`, the same mechanism as
`dragonball-experimental`), so the release tarball ships a KVM-enabled guest
kernel alongside the existing flavors and the Talos extension needs only a `cp`
plus one `sed` line. Happy to take this down once that lands.

---

⚠️ Draft: a full local build of this Dockerfile is still finishing; I will mark it
ready once it completes and I have confirmed `CONFIG_KVM=y` in the produced kernel.


