### PR TITLE
fix(kata-guest-kernel): add traffic-control config for tc-redirect-tap

### DIFF
--- a/apps/kata-guest-kernel/Dockerfile
+++ b/apps/kata-guest-kernel/Dockerfile
@@ -40,17 +40,27 @@ RUN \
 
 WORKDIR /build/linux
 
-# Kata's own config plus KVM host support; the asserts fail the build rather
-# than shipping a kernel that silently cannot nest
+# Kata's own config plus KVM host support, and the traffic-control pieces the
+# Talos QEMU provisioner's tc-redirect-tap CNI plugin needs: Kata enables
+# CONFIG_NET_SCHED but not the ingress qdisc, so `tc qdisc add ingress` fails
+# with ENOENT. The asserts fail the build rather than shipping a kernel that
+# silently cannot nest or cannot wire up a VM's network.
 RUN \
     cp /config-kata .config \
     && ./scripts/config --enable CONFIG_VIRTUALIZATION \
                         --enable CONFIG_KVM \
                         --enable CONFIG_KVM_INTEL \
                         --enable CONFIG_KVM_AMD \
+                        --enable CONFIG_NET_CLS_ACT \
+                        --enable CONFIG_NET_SCH_INGRESS \
+                        --enable CONFIG_NET_CLS_U32 \
+                        --enable CONFIG_NET_ACT_MIRRED \
     && make olddefconfig \
     && grep -q '^CONFIG_KVM=y' .config \
     && grep -q '^CONFIG_KVM_INTEL=y' .config \
+    && grep -q '^CONFIG_NET_SCH_INGRESS=y' .config \
+    && grep -q '^CONFIG_NET_CLS_U32=y' .config \
+    && grep -q '^CONFIG_NET_ACT_MIRRED=y' .config \
     && make -j"$(nproc)" vmlinux \
     && cp vmlinux /vmlinux-nested
 


### PR DESCRIPTION
## What

Adds `CONFIG_NET_CLS_ACT`, `CONFIG_NET_SCH_INGRESS`, `CONFIG_NET_CLS_U32` and
`CONFIG_NET_ACT_MIRRED` to the guest kernel, with matching build-time asserts.

Follow-up to #1659, found by running the actual workload rather than reasoning
about it.

## Why

#1659 gave the guest kernel KVM, which was necessary but — it turns out — not
sufficient. Booting a Talos cluster with `talosctl cluster create --provisioner qemu`
inside a Kata pod gets past KVM and then dies in CNI:

```
plugin type="tc-redirect-tap" failed (add): failed to add ingress qdisc to
device "tap0": no such file or directory
```

Talos's QEMU provisioner wires each node's tap into the netns with
[tc-redirect-tap](https://github.com/awslabs/tc-redirect-tap), which needs an
**ingress qdisc** and a **U32 filter** with a **mirred** redirect action. Kata's
guest config enables `CONFIG_NET_SCHED` and `CONFIG_NET_CLS_CGROUP` but none of
those, so the qdisc simply does not exist in the guest and the plugin fails with
ENOENT.

`CONFIG_NET_CLS_ACT` is included because both `NET_SCH_INGRESS` and
`NET_ACT_MIRRED` depend on it — without it the first build attempt failed its own
asserts, which is the asserts doing their job.

## Verified

Rebuilt and checked the symbols are actually present in the produced kernel, not
just the config:

```
$ nm vmlinux-nested | grep -w 'ingress_qdisc_ops\|clsact_qdisc_ops\|cls_u32_ops\|kvm_init\|vmx_init'
clsact_qdisc_ops
ingress_qdisc_ops
cls_u32_ops
kvm_init
vmx_init
```

## Note for anyone doing this in a container

Two things outside this image are also required, discovered in the same test run:

1. The consumer needs `CAP_NET_ADMIN` **and** `CAP_SYS_ADMIN` — the provisioner
   creates a per-node netns, and `ip netns add` fails with
   `mount --make-shared /var/run/netns failed: Operation not permitted` on
   NET_ADMIN alone.
2. `/proc/sys` is mounted read-only in containers, so the bridge CNI plugin fails
   with `failed to enable forwarding: open /proc/sys/net/ipv4/ip_forward:
   read-only file system`. With `SYS_ADMIN`, `mount -o remount,rw /proc/sys`
   fixes it; that belongs in the consuming workflow, not this image.

## Upstream

[kata-containers#13456](https://github.com/kata-containers/kata-containers/pull/13456)
adds KVM fragments to the base guest config, which would eventually retire the KVM
half of this image. Worth noting there that KVM alone does not make the CI
use-case work — the traffic-control options are needed too.