### PR TITLE
ci: drop unused checkout from app-builder merge job

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -197,11 +197,6 @@ jobs:
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Download Bake Metadata
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
The `merge` job in `app-builder.yaml` checks out the repository and then never touches the workspace: it downloads two artifacts into `RUNNER_TEMP`, logs in to ghcr.io, and drives `docker buildx imagetools` with `working-directory: ${{ runner.temp }}/digests`. Removing the step.

Every other checkout in this repo stays. They are all load-bearing: the `plan`, `build`, `announce` and `notify` jobs call `app-options`, which runs `docker buildx bake` from `./apps/<app>`; `app-tests` runs `go test ./apps/<app>/...`; `app-inventory` reads the `apps/` tree off `process.cwd()`.

Split out from the `$/` self-repository work so this piece can merge on its own.