### PR TITLE
ci: adopt self-repository syntax for local action refs

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -42,19 +42,19 @@ jobs:
           persist-credentials: false
 
       - name: Check For Existing App
-        uses: ./.github/actions/app-exists
+        uses: $/.github/actions/app-exists
         id: app-exists
         with:
           app: ${{ inputs.app }}
 
       - name: Get App Options
-        uses: ./.github/actions/app-options
+        uses: $/.github/actions/app-options
         id: app-options
         with:
           app: ${{ inputs.app }}
 
       - name: Get App Versions
-        uses: ./.github/actions/app-versions
+        uses: $/.github/actions/app-versions
         id: app-versions
         with:
           upstream-version: ${{ steps.app-options.outputs.version }}
@@ -114,7 +114,7 @@ jobs:
             core.setOutput('arch', process.env.PLATFORM.split('/').pop());
 
       - name: Get App Options
-        uses: ./.github/actions/app-options
+        uses: $/.github/actions/app-options
         id: app-options
         with:
           app: ${{ inputs.app }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Run App Tests
         if: ${{ ! inputs.release }}
-        uses: ./.github/actions/app-tests
+        uses: $/.github/actions/app-tests
         with:
           app: ${{ inputs.app }}
           image: ghcr.io/${{ github.repository_owner }}/${{ inputs.app }}:sandbox
@@ -307,13 +307,13 @@ jobs:
           permission-contents: write
 
       - name: Get App Options
-        uses: ./.github/actions/app-options
+        uses: $/.github/actions/app-options
         id: app-options
         with:
           app: ${{ inputs.app }}
 
       - name: Get Release Tag
-        uses: ./.github/actions/release-tag
+        uses: $/.github/actions/release-tag
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -355,7 +355,7 @@ jobs:
 
       - if: ${{ contains(needs.*.result, 'failure') }}
         name: Get App Options
-        uses: ./.github/actions/app-options
+        uses: $/.github/actions/app-options
         id: app-options
         with:
           app: ${{ inputs.app }}

--- a/.github/workflows/deprecate-app.yaml
+++ b/.github/workflows/deprecate-app.yaml
@@ -107,11 +107,6 @@ jobs:
       - merge
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -121,7 +116,7 @@ jobs:
           permission-contents: write
 
       - name: Get Release Tag
-        uses: ./.github/actions/release-tag
+        uses: $/.github/actions/release-tag
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -129,6 +124,7 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag }}
           APP: ${{ inputs.app }}
           REASON: ${{ inputs.reason }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -86,7 +86,7 @@ jobs:
     name: Build ${{ matrix.app }}
     needs:
       - prepare
-    uses: ./.github/workflows/app-builder.yaml
+    uses: $/.github/workflows/app-builder.yaml
     permissions:
       attestations: write
       contents: read

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -124,7 +124,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
     name: Build ${{ matrix.app }}
     needs:
       - changed
-    uses: ./.github/workflows/app-builder.yaml
+    uses: $/.github/workflows/app-builder.yaml
     permissions:
       artifact-metadata: write
       attestations: write

--- a/.github/workflows/test-version.yaml
+++ b/.github/workflows/test-version.yaml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Get App Versions
-        uses: ./.github/actions/app-versions
+        uses: $/.github/actions/app-versions
         id: app-versions
         with:
           upstream-version: ${{ inputs.version }}

--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Get App Inventory
-        uses: ./.github/actions/app-inventory
+        uses: $/.github/actions/app-inventory
         id: inventory
 
   grype:

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -264,6 +264,7 @@ checksum = "sha256:21194bbf41c18d9ec277545c4d14cce8597d57a9d9f494c323d8121a25de3
 url = "https://nodejs.org/dist/v26.5.1/node-v26.5.1-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:34f620b8dad6e8c9188623e46b20f1a07283dcb1b32eba471efb08ca573444b3"
 url = "https://unofficial-builds.nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
@@ -271,6 +272,7 @@ checksum = "sha256:2b07f09c218d473a26442bff5a90151f53f7b7c0a23bad244eda2c26303a2
 url = "https://nodejs.org/dist/v26.5.1/node-v26.5.1-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:95ca909bbb80688262c5b27d98ced7878bdecff2cf1f62069fa7c9c61afc0a5b"
 url = "https://unofficial-builds.nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]


### PR DESCRIPTION
Adopts the [`$/` self-repository syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) announced 2026-07-30. A `uses:` value starting with `$/` resolves to the running workflow's own repository at the exact commit that is running, with no checkout required.

## Changes

- All nine `uses: ./.github/...` references become `uses: $/.github/...`, including the two reusable-workflow calls in `pull-request.yaml` and `release.yaml`.
- The `announce` job in `deprecate-app.yaml` drops its checkout. That step existed only to make `release-tag` available, and `release-tag` is pure API. It now sets `GH_REPO` explicitly, because without a checkout `gh release create` has no git remote to infer the repository from.

Every other checkout stays. They read the `apps/` tree for `docker buildx bake`, `go test`, or app inventory, so `$/` buys nothing there beyond the consistency of a single syntax.

## Draft: blocked on linter support

Both linters in the `workflow-lint` gate reject `$/` as of their latest releases:

- **actionlint 1.7.12** (latest, 2026-03-30) reports `specifying action "$/.github/actions/app-exists" in invalid format because ref is missing`. Tracked upstream as rhysd/actionlint#711.
- **zizmor 1.28.0** (latest, 2026-07-21) cannot parse the file at all and aborts the whole audit with `fatal: no audit was performed`, so it is not a matter of suppressing one rule.

Holding as a draft until both ship support. The commit was made with `--no-verify` for the same reason.