### PR TITLE
fix(hass): remove broken uv find-links install

### DIFF
--- a/apps/home-assistant/entrypoint.sh
+++ b/apps/home-assistant/entrypoint.sh
@@ -6,9 +6,6 @@ mkdir -p "${VENV_FOLDER}"
 uv venv --system-site-packages --link-mode=copy --allow-existing "${VENV_FOLDER}"
 source "${VENV_FOLDER}/bin/activate"
 
-site_packages=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
-uv pip install --no-index --find-links="${site_packages}" uv
-
 ln -sf /proc/self/fd/1 /config/home-assistant.log
 
 exec \


### PR DESCRIPTION
## Summary

Removes the `uv pip install --no-index --find-links=... uv` step from the home-assistant entrypoint. It can never succeed and isn't needed.

## Why it can't succeed

`site_packages` is captured *after* `source "${VENV_FOLDER}/bin/activate"`, so `sysconfig.get_path('purelib')` resolves to the venv's own near-empty site-packages directory, not the system one where `uv` is actually installed (from the `pip install "uv==${HA_UV_VERSION}"` step in the Dockerfile).

Pointing `--find-links` at the *correct* system directory doesn't fix it either — I tested this directly (unsetting `UV_SYSTEM_PYTHON` and capturing `site_packages` before activation, matching the script's real conditions) and it still fails with the same error. `PIP_NO_CACHE_DIR=1` is set earlier in the Dockerfile, so `pip install` never leaves a wheel/sdist artifact behind after installing `uv` — only the unpacked package remains, and `--find-links --no-index` has nothing to install from in either location.

## Why it isn't needed

This step was added in #258 to avoid re-fetching `uv` from the network into the venv on every boot — a reasonable goal. But `uv venv --system-site-packages` (already on the line above it) already satisfies that: the venv inherits the system-installed `uv` package for imports.

I confirmed this covers the actual consumer that matters: `homeassistant/util/package.py`'s `install_package()` — used for every integration and HACS custom-component dependency install — invokes `{sys.executable} -m uv pip install --target <dir> <package>`. I reproduced that exact call from inside the activated venv, immediately after the broken step had already failed, and it installed cleanly with no network fetch of `uv` itself. So removing the step doesn't change what's available at runtime.

## Scope

This is purely the cosmetic boot-time warning reported in #687 and #1260 ("uv was not found in the provided package locations..."). It's unrelated to #794 (stale `/config/deps` shadowing newer packages across upgrades after a HA version bump) — that's a separate `sys.path`-ordering issue this step doesn't touch either way, and this PR doesn't attempt to address it.

## Testing

- `shellcheck apps/home-assistant/entrypoint.sh` passes clean
- Verified in a live running container (2026.7.4) that:
  - The find-links install fails identically whether pointed at the venv's site-packages or the correct system site-packages
  - `python -m uv pip install --target <dir> <package>` (the real dependency-install path) succeeds via `--system-site-packages` inheritance alone