### PR TITLE
fix(plex-next): add Plex GPU driver directories to library search path

### DIFF
--- a/apps/plex-next/entrypoint.sh
+++ b/apps/plex-next/entrypoint.sh
@@ -116,8 +116,9 @@ if [[ "$(readlink -f "${vaDriPath}")" != "/usr/lib/dri" ]]; then
     ln -sf /usr/lib/dri "${vaDriPath}"
 fi
 
-# Plex downloads GPU drivers that dlopen sibling libraries resolved through an
-# $ORIGIN-relative RUNPATH, which musl does not honour, so add them explicitly.
+# Plex's downloaded GPU drivers dlopen sibling libraries by soname. musl credits
+# a dlopen to the main program rather than the calling library, so their own
+# $ORIGIN RUNPATH is never consulted and the paths must be given explicitly.
 for driverDir in "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}/Plex Media Server/Drivers"/*/; do
     [[ -d "${driverDir}" ]] || continue
     echo "Adding driver to library path: $(basename "${driverDir}")"

--- a/apps/plex-next/entrypoint.sh
+++ b/apps/plex-next/entrypoint.sh
@@ -116,6 +116,15 @@ if [[ "$(readlink -f "${vaDriPath}")" != "/usr/lib/dri" ]]; then
     ln -sf /usr/lib/dri "${vaDriPath}"
 fi
 
+# Plex downloads GPU drivers that dlopen sibling libraries resolved through an
+# $ORIGIN-relative RUNPATH, which musl does not honour, so add them explicitly.
+for driverDir in "${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR}/Plex Media Server/Drivers"/*/; do
+    [[ -d "${driverDir}" ]] || continue
+    echo "Adding driver to library path: $(basename "${driverDir}")"
+    LD_LIBRARY_PATH="${driverDir%/}:${LD_LIBRARY_PATH}"
+done
+export LD_LIBRARY_PATH
+
 exec \
     /usr/lib/plexmediaserver/Plex\ Media\ Server \
     "$@"


### PR DESCRIPTION
## Problem

Every HDR to SDR transcode on `plex-next` runs entirely in software. Plex selects `tonemap_opencl`, the kernel build fails, and it falls back to a fully software pipeline (software hevc decode, `format=p010,tonemap=hable`, `libx264`). Sessions report `hwDec=false hwEnc=false`.

```
[Parsed_tonemap_opencl_2 @ 0x7fa603da3fc0] Failed to build program: -6.
```

On my cluster two concurrent HDR streams pushed a single node to 91% CPU, with Plex alone taking 15.3 of 17.95 allocatable cores.

## Cause

Plex downloads its own Intel Compute Runtime at runtime into the config volume, not the image:

```
Library/Application Support/Plex Media Server/Drivers/icr-<hash>-linux-x86_64/
  libigdrcl.so           Intel OpenCL ICD
  libigc.so.2            Intel Graphics Compiler
  libigdfcl.so.2
  libopencl-clang.so.15
```

`libigdrcl.so` declares an `$ORIGIN`-relative RUNPATH, and loads its compiler backend by soname at runtime rather than as a link-time dependency:

```console
$ readelf -d libigdrcl.so | grep -E 'RUNPATH|NEEDED'
 0x000000000000001d (RUNPATH)   Library runpath: [$ORIGIN:$ORIGIN/..]
 0x0000000000000001 (NEEDED)    Shared library: [libgcompat.so.0]
 0x0000000000000001 (NEEDED)    Shared library: [libigdgmm.so.12]
 0x0000000000000001 (NEEDED)    Shared library: [libc++.so.2]
 0x0000000000000001 (NEEDED)    Shared library: [libc.so]
```

`libigc.so.2` is absent from `NEEDED`, so it is only looked up when the driver `dlopen`s it. musl does expand `$ORIGIN`, but it credits a `dlopen` to the main program rather than to the calling library. In `ldso/dynlink.c`, a `DT_NEEDED` dependency is loaded with the requesting DSO as `needed_by`:

```c
struct dso *dep = load_library(p->strings + p->dynv[i+1], p);
```

whereas `dlopen` passes `head`:

```c
} else p = load_library(file, head);
```

The rpath walk only consults the `needed_by` chain, so `libigdrcl.so`'s own RUNPATH is never searched for the library it `dlopen`s. glibc resolves this through the calling object's link map, which is why the same driver bundle works on the previous Ubuntu image. With `LD_LIBRARY_PATH="/lib:/usr/lib"` the compiler is never found, `clBuildProgram` fails, and the hardware path is abandoned.

## Fix

Prepend the driver directories to `LD_LIBRARY_PATH` in the entrypoint. The directory name carries a content hash that changes with each Plex driver bundle, so it is globbed rather than hardcoded.

## Verification

Tested against the live container on Meteor Lake (Core Ultra 5 125H, Xe-LPG), running `tonemap_opencl` on a 2160p DV/HDR10 HEVC source. Only `LD_LIBRARY_PATH` differs between arms.

| `LD_LIBRARY_PATH` | Result |
| --- | --- |
| `/lib:/usr/lib` (current image) | `Failed to build program: -6` |
| driver dirs prepended (this PR) | `frame= 5`, nv12 3840x1604, tone mapped on GPU |

Also checked:

- `shellcheck` clean, `bash -n` clean.
- Loop tested with driver directories present and absent, so a fresh install with no `Drivers/` directory yet leaves `LD_LIBRARY_PATH` untouched.
- Paths containing spaces are handled.
- VA-API is unaffected. It already resolves through the existing `va-dri` symlink to `/usr/lib/dri` and keeps using the image's `intel-media-driver`.

## Alternatives considered

**A static `ENV LD_LIBRARY_PATH` in the Dockerfile.** There is no fixed path to point at. The directory is `icr-<content-hash>-linux-x86_64` and the hash changes with each driver bundle, so a hardcoded value would silently fall back to software transcoding the next time Plex updates its drivers. The `$ORIGIN/..` parent holds no libraries.

**Installing `intel-graphics-compiler` in the Dockerfile.** This would work, since the package provides `so:libigc.so.2`, `so:libigdfcl.so.2` and `so:libopencl-clang.so.15`, and `/usr/lib` is already searched. Rejected because:

- It adds roughly 217 MB installed to every image, including arm64 and the majority of users with no Intel GPU.
- It pairs Plex's Compute Runtime 24.52 with Alpine's IGC 2.14.0, while Plex ships and validates against IGC 2.16.0 in the same bundle. Since `/usr/lib` is searched and the driver's own directory is not, the distro compiler would always win and permanently shadow the matched one.

Using the drivers Plex ships together keeps that pairing intact and costs nothing in image size.

## Note

`LD_LIBRARY_PATH` is computed at container start. If Plex downloads a driver bundle for the first time during a running session, it is picked up on the next restart. The drivers persist on the config volume, so this only affects a first run.
