### PR TITLE
fix(plex-next): install Intel Graphics Compiler for OpenCL tone mapping

### DIFF
--- a/apps/plex-next/Dockerfile
+++ b/apps/plex-next/Dockerfile
@@ -52,12 +52,14 @@ RUN \
         tzdata \
         xmlstarlet \
     && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    apk add --no-cache \
+        --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
         libdrm \
         libva \
         mesa-dri-gallium \
         mesa-va-gallium \
-        $( [ "${TARGETARCH}" = "amd64" ] && echo intel-media-driver ) \
+        $( [ "${TARGETARCH}" = "amd64" ] && echo intel-media-driver intel-graphics-compiler ) \
     && \
     apk add --no-cache --virtual=.build-deps \
         dpkg \


### PR DESCRIPTION
Alternative to #1731. Same bug, different fix. Only one of these should merge.

## Problem

Every HDR to SDR transcode runs entirely in software. Plex selects `tonemap_opencl`, the kernel build fails, and it falls back to a fully software pipeline (software hevc decode, `format=p010,tonemap=hable`, `libx264`). Sessions report `hwDec=false hwEnc=false`.

```
[Parsed_tonemap_opencl_2 @ 0x7fa603da3fc0] Failed to build program: -6.
```

On my cluster two concurrent HDR streams pushed a single node to 91% CPU, with Plex alone taking 15.3 of 17.95 allocatable cores.

## Cause

Plex downloads its own Intel Compute Runtime into the config volume, not the image. The ICD it ships declares an `$ORIGIN`-relative RUNPATH and loads its compiler backend by soname at runtime rather than as a link-time dependency:

```console
$ readelf -d libigdrcl.so | grep -E 'RUNPATH|NEEDED'
 0x000000000000001d (RUNPATH)   Library runpath: [$ORIGIN:$ORIGIN/..]
 0x0000000000000001 (NEEDED)    Shared library: [libgcompat.so.0]
 0x0000000000000001 (NEEDED)    Shared library: [libigdgmm.so.12]
 0x0000000000000001 (NEEDED)    Shared library: [libc++.so.2]
 0x0000000000000001 (NEEDED)    Shared library: [libc.so]
```

`libigc.so.2` is absent from `NEEDED`, so it is only looked up when the driver `dlopen`s it. musl does expand `$ORIGIN`, but it credits a `dlopen` to the main program rather than to the calling library. In `ldso/dynlink.c` a `DT_NEEDED` dependency is loaded with the requesting DSO as `needed_by`, whereas `dlopen` passes `head`:

```c
struct dso *dep = load_library(p->strings + p->dynv[i+1], p);   // DT_NEEDED
} else p = load_library(file, head);                             // dlopen
```

The rpath walk only follows the `needed_by` chain, so the driver's own RUNPATH is never searched for the library it `dlopen`s. glibc resolves this through the calling object's link map, which is why the same driver bundle worked on the previous Ubuntu image.

## Fix

Install `intel-graphics-compiler`, which puts `libigc.so.2` in `/usr/lib`. That is already on the search path, so the driver resolves it with no RUNPATH lookup and no entrypoint changes. The package is `x86_64` only in aports, so it follows the existing amd64 conditional. `spirv-tools` comes along as a dependency from edge/main.

## Verification

Tested on Meteor Lake (Core Ultra 5 125H, Xe-LPG) against a 2160p DV/HDR10 HEVC source, with the package staged so `libigdrcl.so` resolves Alpine's IGC exactly as it would once installed.

| Compiler reachable | Frames processed | Build failures |
| --- | --- | --- |
| Alpine IGC 2.14.0 (this PR) | 8 | 0 |
| Plex's own IGC 2.16.0 (#1731) | 8 | 0 |
| none (current image) | 0 | 1 |

Alpine's IGC 2.14.0 drives Plex's Compute Runtime 24.52 without complaint, so the version difference against the 2.16.0 Plex bundles is not a problem in practice.

## Cost

Measured by installing the package on top of the published `1.43.3.10861` image:

| | Uncompressed | Compressed |
| --- | --- | --- |
| current | 546 MB | 203 MB |
| with IGC | 764 MB | ~293 MB |
| delta | +218 MB | +90 MB |

amd64 only. arm64 is unaffected.

## Trade-off against #1731

Both are verified working on the same hardware.

| | Image cost | Compiler used | Caveat |
| --- | --- | --- | --- |
| #1731, entrypoint `LD_LIBRARY_PATH` | none | the 2.16.0 Plex ships alongside its runtime | needs one restart if a driver bundle is downloaded for the first time mid-session |
| this PR, Dockerfile package | +90 MB compressed on amd64 | Alpine's 2.14.0 | none |

Worth noting that Plex downloads its ~195 MB driver bundle to the config volume either way, since `libigdrcl.so` itself only comes from there. This package shadows the compiler inside that bundle rather than avoiding the download. The same already happens for VA-API: the image ships `intel-media-driver` and Plex still downloads its own `imd-*` bundle, which is what the existing `va-dri` symlink works around.

I lean toward #1731 on cost alone, but this is the simpler mechanism and has no restart caveat.
