### PR TITLE
fix(github-action): deprecation flow for merge queue

### DIFF
--- a/.github/workflows/announce-deprecation.yaml
+++ b/.github/workflows/announce-deprecation.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Announce Deprecation
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    if: >-
+      github.event.pull_request.merged &&
+      startsWith(github.event.pull_request.head.ref, 'deprecate/') &&
+      contains(github.event.pull_request.labels.*.name, 'deprecation')
+    name: Announce (${{ github.event.pull_request.head.ref }})
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Extract Deprecation Details
+        id: details
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "app=${HEAD_REF#deprecate/}" >> "$GITHUB_OUTPUT"
+          echo "reason=$(sed -n 's/^\*\*Reason\*\*: //p' <<< "${PR_BODY}" | tr -d '\r' | head -n1)" >> "$GITHUB_OUTPUT"
+
+      - name: Get Release Tag
+        uses: $/.github/actions/release-tag
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag }}
+          APP: ${{ steps.details.outputs.app }}
+          REASON: ${{ steps.details.outputs.reason }}
+        run: |
+          cat > release-notes.md <<EOF
+          > [!WARNING]
+          > An app has been deprecated and will no longer receive updates.
+          > After **6 months** from now, its image will be **removed** from our container registry.
+
+          ## 📦 App
+
+          **Name**: ${APP}
+          **Reason**: ${REASON}
+          EOF
+          gh release create "$TAG" --notes-file release-notes.md

--- a/.github/workflows/deprecate-app.yaml
+++ b/.github/workflows/deprecate-app.yaml
@@ -65,6 +65,7 @@ jobs:
             **Reason**: ${{ inputs.reason }}
           branch: deprecate/${{ inputs.app }}
           commit-message: "release(${{ inputs.app }})!: deprecate app image"
+          labels: ${{ inputs.release && 'deprecation' || '' }}
           sign-commits: true
           signoff: true
           title: "release(${{ inputs.app }})!: deprecate app image"
@@ -93,50 +94,23 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            await github.rest.pulls.merge({
+            const pull_number = Number(process.env.PULL_NUMBER);
+            const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: Number(process.env.PULL_NUMBER),
-              merge_method: 'squash',
+              pull_number,
             });
-
-  announce:
-    if: ${{ inputs.release }}
-    name: Announce (${{ inputs.app }})
-    needs:
-      - merge
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Generate Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.BOT_CLIENT_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          permission-contents: write
-
-      - name: Get Release Tag
-        uses: $/.github/actions/release-tag
-        id: release
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Create Release
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG: ${{ steps.release.outputs.tag }}
-          APP: ${{ inputs.app }}
-          REASON: ${{ inputs.reason }}
-        run: |
-          cat > release-notes.md <<EOF
-          > [!WARNING]
-          > An app has been deprecated and will no longer receive updates.
-          > After **6 months** from now, its image will be **removed** from our container registry.
-
-          ## 📦 App
-
-          **Name**: ${APP}
-          **Reason**: ${REASON}
-          EOF
-          gh release create "$TAG" --notes-file release-notes.md
+            try {
+              await github.graphql(
+                'mutation($id: ID!) { enqueuePullRequest(input: { pullRequestId: $id }) { clientMutationId } }',
+                { id: pr.node_id },
+              );
+              core.info(`Added #${pull_number} to the merge queue`);
+            } catch (error) {
+              // enqueue is rejected while required checks are still running
+              core.info(`Enqueue failed (${error.message}), enabling auto-merge instead`);
+              await github.graphql(
+                'mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id }) { clientMutationId } }',
+                { id: pr.node_id },
+              );
+            }


### PR DESCRIPTION
The deprecate-app workflow merged its PR with a direct API squash merge, which the merge queue ruleset now rejects with a 405 (run 32759507592). The merge job now enqueues the PR via GraphQL (`enqueuePullRequest`, falling back to `enablePullRequestAutoMerge` while checks are still running), and the announce/release step moves to a new `announce-deprecation.yaml` triggered by the merged PR itself (gated on the new `deprecation` label, applied only when the `release` input is true), so nothing polls for the queue to finish.